### PR TITLE
Unregister shortcut before setting a new one

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -197,8 +197,12 @@ public enum KeyboardShortcuts {
 			return
 		}
 
-		UserDefaults.standard.set(encoded, forKey: userDefaultsKey(for: name))
+		if let oldShortcut = userDefaultsGet(name: name) {
+			unregister(oldShortcut)
+		}
+
 		register(shortcut)
+		UserDefaults.standard.set(encoded, forKey: userDefaultsKey(for: name))
 		userDefaultsDidChange(name: name)
 	}
 


### PR DESCRIPTION
I encountered the following bug using `RecorderCocoa`:
- the user configures a custom shortcut which is already used by the system (`CMD+A` for instance)
- this custom shortcut overwrites the system shortcut (desired behavior)
- the user changes the shortcut with a new one, by clicking into the `RecorderCocoa` input
- then, this new shortcut works, but the default behavior of the previous shortcut (`CMD+A`) does not work anymore, until the app is killed.

This bug does not occur when the user clicks on the "X" button before setting the new shortcut. It appears that in this case, the method `userDefaultsRemove` manages to properly remove the current shortcut. In this PR, I'm adding a call to this method before setting the new shortcut, even when the user does not click on that "X" button.

PS: thanks a lot for this awesome package!