### PR TITLE
Add optional change callback to `Recorder` and `RecorderCocoa`

### DIFF
--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -30,13 +30,15 @@ extension KeyboardShortcuts {
 		public typealias NSViewType = RecorderCocoa
 
 		private let name: Name
+		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
 
-		public init(for name: Name) {
+		public init(for name: Name, onChange: ((_ shortcut: Shortcut?) -> Void)? = nil) {
 			self.name = name
+			self.onChange = onChange
 		}
 
 		/// :nodoc:
-		public func makeNSView(context: Context) -> NSViewType { .init(for: name) }
+		public func makeNSView(context: Context) -> NSViewType { .init(for: name, onChange: onChange) }
 
 		/// :nodoc:
 		public func updateNSView(_ nsView: NSViewType, context: Context) {}

--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -24,16 +24,6 @@ extension KeyboardShortcuts {
 		}
 	}
 	```
-	
-	An optional onChange callback can be set on the Recorder which will be called when the shortcut is sucessfully changed/removed.
-	
-	This could be useful if you would like to store the keyboard shortcut somewhere yourself instead of rely on the build-in `UserDefaults` storage.
-	
-	```
-	KeyboardShortcuts.Recorder(for: .toggleUnicornMode, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
-	  print("Changed shortcut to:", shortcut)
-	})
-	```
 	*/
 	public struct Recorder: NSViewRepresentable { // swiftlint:disable:this type_name
 		/// :nodoc:
@@ -42,6 +32,16 @@ extension KeyboardShortcuts {
 		private let name: Name
 		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
 
+		/**
+		  Creates a new Recorder view
+		  - Parameter name: strongly typed `KeyboardShortcuts.Name`
+		  - Parameter onChange: optional callback which will be called when the shortcut is successfully changed/removed. This could be useful if you would like to store the keyboard shortcut somewhere yourself instead of rely on the build-in `UserDefaults` storage.
+		  ```
+		  KeyboardShortcuts.Recorder(for: .toggleUnicornMode, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
+		    print("Changed shortcut to:", shortcut)
+		  })
+		  ```
+		**/
 		public init(for name: Name, onChange: ((_ shortcut: Shortcut?) -> Void)? = nil) {
 			self.name = name
 			self.onChange = onChange

--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -24,6 +24,16 @@ extension KeyboardShortcuts {
 		}
 	}
 	```
+	
+	An optional onChange callback can be set on the Recorder which will be called when the shortcut is sucessfully changed/removed.
+	
+	This could be useful if you would like to store the keyboard shortcut somewhere yourself instead of rely on the build-in `UserDefaults` storage.
+	
+	```
+	KeyboardShortcuts.Recorder(for: .toggleUnicornMode, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
+	  print("Changed shortcut to:", shortcut)
+	})
+	```
 	*/
 	public struct Recorder: NSViewRepresentable { // swiftlint:disable:this type_name
 		/// :nodoc:

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -226,7 +226,6 @@ extension KeyboardShortcuts {
 			return shouldBecomeFirstResponder
 		}
 
-		/// :nodoc:
 		private func saveShortcut(_ shortcut: Shortcut?) {
 			if let shortcut = shortcut {
 				userDefaultsSet(name: shortcutName, shortcut: shortcut)

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -24,16 +24,6 @@ extension KeyboardShortcuts {
 		}
 	}
 	```
-	
-	An optional onChange callback can be set on the Recorder which will be called when the shortcut is sucessfully changed/removed.
-	
-	This could be useful if you would like to store the keyboard shortcut somewhere yourself instead of rely on the build-in `UserDefaults` storage.
-	
-	```
-	KeyboardShortcuts.RecorderCocoa(for: .toggleUnicornMode, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
-	  print("Changed shortcut to:", shortcut)
-	})
-	```
 	*/
 	public final class RecorderCocoa: NSSearchField, NSSearchFieldDelegate {
 		private let minimumWidth: Double = 130
@@ -60,6 +50,16 @@ extension KeyboardShortcuts {
 			}
 		}
 
+		/**
+		  Creates a new RecorderCocoa view
+		  - Parameter name: strongly typed `KeyboardShortcuts.Name`
+		  - Parameter onChange: optional callback which will be called when the shortcut is successfully changed/removed. This could be useful if you would like to store the keyboard shortcut somewhere yourself instead of rely on the build-in `UserDefaults` storage.
+		  ```
+		  KeyboardShortcuts.RecorderCocoa(for: .toggleUnicornMode, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
+		    print("Changed shortcut to:", shortcut)
+		  })
+		  ```
+		**/
 		public required init(for name: Name, onChange: ((_ shortcut: Shortcut?) -> Void)? = nil) {
 			self.shortcutName = name
 			self.onChange = onChange

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -94,7 +94,7 @@ extension KeyboardShortcuts {
 		/// :nodoc:
 		public func controlTextDidChange(_ object: Notification) {
 			if stringValue.isEmpty {
-				self.saveShortcut(nil)
+				saveShortcut(nil)
 			}
 
 			showsCancelButton = !stringValue.isEmpty

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -24,6 +24,16 @@ extension KeyboardShortcuts {
 		}
 	}
 	```
+	
+	An optional onChange callback can be set on the Recorder which will be called when the shortcut is sucessfully changed/removed.
+	
+	This could be useful if you would like to store the keyboard shortcut somewhere yourself instead of rely on the build-in `UserDefaults` storage.
+	
+	```
+	KeyboardShortcuts.RecorderCocoa(for: .toggleUnicornMode, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
+	  print("Changed shortcut to:", shortcut)
+	})
+	```
 	*/
 	public final class RecorderCocoa: NSSearchField, NSSearchFieldDelegate {
 		private let minimumWidth: Double = 130
@@ -224,9 +234,7 @@ extension KeyboardShortcuts {
 				userDefaultsRemove(name: shortcutName)
 			}
 
-			if let onChange = self.onChange {
-				onChange(shortcut)
-			}
+			onChange?(shortcut)
 		}
 	}
 }


### PR DESCRIPTION
Adds ability to register callback when a Recorder view's value is changed/removed.

```swift
KeyboardShortcuts.Recorder(for: .doSomething, onChange: { (shortcut: KeyboardShortcuts.Shortcut?) in
  print(shortcut)
})
```
Closes #11 