### PR TITLE
Add ability to set default shortcut

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -211,9 +211,13 @@ public enum KeyboardShortcuts {
 			return
 		}
 
-		UserDefaults.standard.removeObject(forKey: userDefaultsKey(for: name))
+		UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
 		unregister(shortcut)
 		userDefaultsDidChange(name: name)
+	}
+
+	static func userDefaultsContains(name: Name) -> Bool {
+		UserDefaults.standard.object(forKey: userDefaultsKey(for: name)) != nil
 	}
 }
 

--- a/Sources/KeyboardShortcuts/Name.swift
+++ b/Sources/KeyboardShortcuts/Name.swift
@@ -13,14 +13,26 @@ extension KeyboardShortcuts {
 	```
 	*/
 	public struct Name: Hashable {
-		// This is to allow `extension KeyboardShortcuts.Name { static let x = Name("x") }`.
+		// These are to allow using the types without the namespace
+		// `extension KeyboardShortcuts.Name { static let x = Name("x") }`.
 		/// :nodoc:
 		public typealias Name = KeyboardShortcuts.Name
+		/// :nodoc:
+		public typealias Shortcut = KeyboardShortcuts.Shortcut
 
 		public let rawValue: String
 
-		public init(_ name: String) {
+		/**
+		Creates a strongly-typed name of the keyboard shortcut.
+		- Parameter name: name of shortcut
+		- Parameter default: optional default key combination for the shortcut
+		*/
+		public init(_ name: String, default defaultShortcut: Shortcut? = nil) {
 			self.rawValue = name
+
+			if let defaultShortcut = defaultShortcut {
+				KeyboardShortcuts.userDefaultsSet(name: self, shortcut: defaultShortcut)
+			}
 		}
 	}
 }

--- a/Sources/KeyboardShortcuts/Name.swift
+++ b/Sources/KeyboardShortcuts/Name.swift
@@ -30,8 +30,8 @@ extension KeyboardShortcuts {
 		public init(_ name: String, default defaultShortcut: Shortcut? = nil) {
 			self.rawValue = name
 
-			if let defaultShortcut = defaultShortcut {
-				KeyboardShortcuts.userDefaultsSet(name: self, shortcut: defaultShortcut)
+			if let defaultShortcut = defaultShortcut, userDefaultsGet(name: self) == nil {
+				userDefaultsSet(name: self, shortcut: defaultShortcut)
 			}
 		}
 	}

--- a/Sources/KeyboardShortcuts/Name.swift
+++ b/Sources/KeyboardShortcuts/Name.swift
@@ -31,7 +31,7 @@ extension KeyboardShortcuts {
 
 			if
 				let defaultShortcut = defaultShortcut,
-				userDefaultsGet(name: self) == nil
+				!userDefaultsContains(name: self)
 			{
 				userDefaultsSet(name: self, shortcut: defaultShortcut)
 			}

--- a/Sources/KeyboardShortcuts/Name.swift
+++ b/Sources/KeyboardShortcuts/Name.swift
@@ -13,7 +13,7 @@ extension KeyboardShortcuts {
 	```
 	*/
 	public struct Name: Hashable {
-		// These are to allow using the types without the namespace
+		// These make it possible to use the types without the namespace.
 		// `extension KeyboardShortcuts.Name { static let x = Name("x") }`.
 		/// :nodoc:
 		public typealias Name = KeyboardShortcuts.Name
@@ -23,14 +23,16 @@ extension KeyboardShortcuts {
 		public let rawValue: String
 
 		/**
-		Creates a strongly-typed name of the keyboard shortcut.
-		- Parameter name: name of shortcut
-		- Parameter default: optional default key combination for the shortcut
+		- Parameter name: Name of the shortcut.
+		- Parameter default: Optional default key combination for the shortcut. Do not set this unless it's essential. Users find it annoying when random apps steal their existing keyboard shortcuts. It's generally better to show a welcome screen on the first app launch that lets the user set the shortcut.
 		*/
 		public init(_ name: String, default defaultShortcut: Shortcut? = nil) {
 			self.rawValue = name
 
-			if let defaultShortcut = defaultShortcut, userDefaultsGet(name: self) == nil {
+			if
+				let defaultShortcut = defaultShortcut,
+				userDefaultsGet(name: self) == nil
+			{
 				userDefaultsSet(name: self, shortcut: defaultShortcut)
 			}
 		}


### PR DESCRIPTION
Allows you to set a default key combination when defining a shortcut name.
```swift
extension KeyboardShortcuts.Name {
	static let toggleUnicornMode = Name("toggleUnicornMode", default: Shortcut(.a, modifiers: [.command]))
}
```
~Caveat: If you remove the default shortcut in the UI and restart the app, the default will always take over.  Would need to store a null value in user defaults or something.~

Closes #7