### PR TITLE
Add method to remove all handlers

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -45,7 +45,7 @@ public enum KeyboardShortcuts {
 
 		// TODO: Should remove user defaults too.
 	}
-	
+
 	/**
 	Remove all handlers receiving keyboard shortcuts events.
 	*/

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -48,6 +48,8 @@ public enum KeyboardShortcuts {
 
 	/**
 	Remove all handlers receiving keyboard shortcuts events.
+	
+	This can be used to reset the handlers before re-creating them to avoid having multiple handlers for the same shortcut.
 	*/
 	public static func removeAllHandlers() {
 		keyDownHandlers = [:]

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -45,6 +45,16 @@ public enum KeyboardShortcuts {
 
 		// TODO: Should remove user defaults too.
 	}
+	
+	/**
+	Remove all handlers receiving keyboard shortcuts events.
+	*/
+	public static func removeAllHandlers() {
+		keyDownHandlers = [:]
+		keyUpHandlers = [:]
+		userDefaultsKeyDownHandlers = [:]
+		userDefaultsKeyUpHandlers = [:]
+	}
 
 	// TODO: Also add `.isEnabled(_ name: Name)`.
 	/**


### PR DESCRIPTION
This is required if your keyboard shortcut names are dynamic (eg. they depend on user content) and you want to reset the handlers before re-creating them to avoid having multiple handlers for the same shortcut.