### PR TITLE
Unregisters Carbon hot keys with `KeyboardShortcuts.removeAllHandlers()`

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -52,6 +52,7 @@ public enum KeyboardShortcuts {
 	This can be used to reset the handlers before re-creating them to avoid having multiple handlers for the same shortcut.
 	*/
 	public static func removeAllHandlers() {
+		CarbonKeyboardShortcuts.unregisterAll()
 		keyDownHandlers = [:]
 		keyUpHandlers = [:]
 		userDefaultsKeyDownHandlers = [:]


### PR DESCRIPTION
Addendum to #36 to ensure no Carbon hot keys are left registered without valid handlers.