### PR TITLE
Fix `RecorderCocoa` when embedded in certain views

### DIFF
--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -170,7 +170,7 @@ extension KeyboardShortcuts {
 
 				if
 					event.type == .leftMouseUp || event.type == .rightMouseUp,
-					!self.frame.insetBy(dx: -clickMargin, dy: -clickMargin).contains(clickPoint)
+					!self.bounds.insetBy(dx: -clickMargin, dy: -clickMargin).contains(clickPoint)
 				{
 					self.blur()
 					return nil


### PR DESCRIPTION
## Summary

Fixes: #41 

We use `self.convert` to convert `event.locationWindow` to its coordinate system.
But `self.frame` is using its superview's coordinate system.
So we have to use `self.bounds` instead.

Thank you for the code review 😄 !