### PR TITLE
Support for controlSize(:) and frame(width:) modifier

### DIFF
--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -31,39 +31,70 @@ extension KeyboardShortcuts {
 
 		private let name: Name
 		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
+        private let isHorizontalContentSizeConstraintActive: Bool
 
-		/**
-		- Parameter name: Strongly-typed keyboard shortcut name.
-		- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-		*/
+        /**
+         - Parameter name: Strongly-typed keyboard shortcut name.
+         - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+         - Parameter isHorizontalContentSizeConstraintActive: When `true`, makes sure to have width constraint set to avoid cutting placeholder string. When `false`, the frame(:) modifier will control the actual width of the text field.
+         */
 		public init(
 			for name: Name,
-			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil
+			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil,
+            constraint isHorizontalContentSizeConstraintActive: Bool = false
 		) {
 			self.name = name
 			self.onChange = onChange
+            self.isHorizontalContentSizeConstraintActive = isHorizontalContentSizeConstraintActive
 		}
 
 		/// :nodoc:
-		public func makeNSView(context: Context) -> NSViewType { .init(for: name, onChange: onChange) }
+		public func makeNSView(context: Context) -> NSViewType { .init(for: name, onChange: onChange, isHorizontalContentSizeConstraintActive: isHorizontalContentSizeConstraintActive) }
 
 		/// :nodoc:
 		public func updateNSView(_ nsView: NSViewType, context: Context) {
 			nsView.shortcutName = name
+            
+            // support for controlSize(:) modifier
+            switch context.environment.controlSize {
+                case .small:
+                    nsView.font = .systemFont(ofSize: 11)
+                    nsView.changeWidth(width: 110)
+                case .mini:
+                    nsView.font = .systemFont(ofSize: 9)
+                    nsView.changeWidth(width: 95)
+                default:
+                    break
+            }
 		}
 	}
 }
 
 @available(macOS 10.15, *)
 struct SwiftUI_Previews: PreviewProvider {
-	static var previews: some View {
+    static var previews: some View {
 		Group {
 			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
 				.environment(\.locale, .init(identifier: "en"))
-			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
-				.environment(\.locale, .init(identifier: "zh-Hans"))
-			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
-				.environment(\.locale, .init(identifier: "ru"))
+                .frame(width: 130)
+            
+            KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+                .previewDisplayName("Test: .controlSize(.small)")
+                .environment(\.locale, .init(identifier: "en"))
+                .controlSize(.small)
+                .frame(width: 110)
+            
+            KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+                .previewDisplayName("Test: .controlSize(.mini)")
+                .environment(\.locale, .init(identifier: "en"))
+                .controlSize(.mini)
+                .frame(width: 95)
+                
+            KeyboardShortcuts.Recorder(for: .init("xcodePreview"), constraint: true)
+                .previewDisplayName("Test: Horizontal constraint")
+                .environment(\.locale, .init(identifier: "en"))
+                .frame(width: 50)
 		}
+        .padding()
 	}
 }

--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -31,70 +31,66 @@ extension KeyboardShortcuts {
 
 		private let name: Name
 		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
-        private let isHorizontalContentSizeConstraintActive: Bool
 
-        /**
-         - Parameter name: Strongly-typed keyboard shortcut name.
-         - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-         - Parameter isHorizontalContentSizeConstraintActive: When `true`, makes sure to have width constraint set to avoid cutting placeholder string. When `false`, the frame(:) modifier will control the actual width of the text field.
-         */
+		/**
+		- Parameter name: Strongly-typed keyboard shortcut name.
+		- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+		*/
 		public init(
 			for name: Name,
-			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil,
-            constraint isHorizontalContentSizeConstraintActive: Bool = false
+			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil
 		) {
 			self.name = name
 			self.onChange = onChange
-            self.isHorizontalContentSizeConstraintActive = isHorizontalContentSizeConstraintActive
 		}
 
 		/// :nodoc:
-		public func makeNSView(context: Context) -> NSViewType { .init(for: name, onChange: onChange, isHorizontalContentSizeConstraintActive: isHorizontalContentSizeConstraintActive) }
+		public func makeNSView(context: Context) -> NSViewType { .init(for: name, onChange: onChange) }
 
 		/// :nodoc:
 		public func updateNSView(_ nsView: NSViewType, context: Context) {
 			nsView.shortcutName = name
-            
-            // support for controlSize(:) modifier
-            switch context.environment.controlSize {
-                case .small:
-                    nsView.font = .systemFont(ofSize: 11)
-                    nsView.changeWidth(width: 110)
-                case .mini:
-                    nsView.font = .systemFont(ofSize: 9)
-                    nsView.changeWidth(width: 95)
-                default:
-                    break
-            }
+			
+			// support for controlSize(:) modifier
+			switch context.environment.controlSize {
+				case .small:
+					nsView.font = .systemFont(ofSize: NSFont.systemFontSize(for: .small))
+					nsView.changeWidth(for: .small)
+				case .mini:
+					nsView.font = .systemFont(ofSize: NSFont.systemFontSize(for: .mini))
+					nsView.changeWidth(for: .mini)
+				default:
+					break
+			}
 		}
 	}
 }
 
 @available(macOS 10.15, *)
 struct SwiftUI_Previews: PreviewProvider {
-    static var previews: some View {
+	static var previews: some View {
 		Group {
 			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
 				.environment(\.locale, .init(identifier: "en"))
-                .frame(width: 130)
-            
-            KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
-                .previewDisplayName("Test: .controlSize(.small)")
-                .environment(\.locale, .init(identifier: "en"))
-                .controlSize(.small)
-                .frame(width: 110)
-            
-            KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
-                .previewDisplayName("Test: .controlSize(.mini)")
-                .environment(\.locale, .init(identifier: "en"))
-                .controlSize(.mini)
-                .frame(width: 95)
-                
-            KeyboardShortcuts.Recorder(for: .init("xcodePreview"), constraint: true)
-                .previewDisplayName("Test: Horizontal constraint")
-                .environment(\.locale, .init(identifier: "en"))
-                .frame(width: 50)
+				.frame(width: 130)
+			
+			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+				.previewDisplayName("Test: .controlSize(.small)")
+				.environment(\.locale, .init(identifier: "en"))
+				.controlSize(.small)
+				.frame(width: 110)
+			
+			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+				.previewDisplayName("Test: .controlSize(.mini)")
+				.environment(\.locale, .init(identifier: "en"))
+				.controlSize(.mini)
+				.frame(width: 95)
+				
+			KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+				.previewDisplayName("Test: Horizontal constraint")
+				.environment(\.locale, .init(identifier: "en"))
+				.frame(width: 50)
 		}
-        .padding()
+		.padding()
 	}
 }

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -70,12 +70,10 @@ extension KeyboardShortcuts {
         /**
          - Parameter name: Strongly-typed keyboard shortcut name.
          - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-         - Parameter isHorizontalContentSizeConstraintActive: When `true`, makes sure to have width constraint set to avoid cutting placeholder string. When `false`, the frame(:) modifier will control the actual width of the text field.
          */
 		public required init(
 			for name: Name,
-			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil,
-            isHorizontalContentSizeConstraintActive: Bool = false
+			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil
 		) {
 			self.shortcutName = name
 			self.onChange = onChange
@@ -91,7 +89,6 @@ extension KeyboardShortcuts {
 			self.translatesAutoresizingMaskIntoConstraints = false
 			setContentHuggingPriority(.defaultHigh, for: .vertical)
 			setContentHuggingPriority(.defaultLow, for: .horizontal)
-            self.isHorizontalContentSizeConstraintActive = isHorizontalContentSizeConstraintActive
 
 			// Hide the cancel button when not showing the shortcut so the placeholder text is properly centered. Must be last.
 			self.cancelButton = (cell as? NSSearchFieldCell)?.cancelButtonCell
@@ -100,6 +97,21 @@ extension KeyboardShortcuts {
 
 			setUpEvents()
 		}
+        
+        /**
+         - Parameter name: Strongly-typed keyboard shortcut name.
+         - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+         - Parameter isHorizontalContentSizeConstraintActive: When `true`, makes sure to have width constraint set to avoid a cluttering placeholder string visibility. When `false`, the frame(:) modifier will control the actual width of the text field.
+         */
+        @available(macOS 10.15, *)
+        public convenience init(
+            for name: Name,
+            onChange: ((_ shortcut: Shortcut?) -> Void)? = nil,
+            isHorizontalContentSizeConstraintActive: Bool = false
+        ) {
+            self.init(for: name, onChange: onChange)
+            self.isHorizontalContentSizeConstraintActive = isHorizontalContentSizeConstraintActive
+        }
 
 		@available(*, unavailable)
 		public required init?(coder: NSCoder) {

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -26,10 +26,14 @@ extension KeyboardShortcuts {
 	```
 	*/
 	public final class RecorderCocoa: NSSearchField, NSSearchFieldDelegate {
-		private var intrinsicWidth: CGFloat = 130
 		private var eventMonitor: LocalEventMonitor?
 		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
 		private var observer: NSObjectProtocol?
+		private var intrinsicWidth: CGFloat = 130
+		
+		private let intrinsicWidthRegular: CGFloat = 130
+		private let intrinsicWidthSmall: CGFloat = 110
+		private let intrinsicWidthMini: CGFloat = 95
 
 		/// The shortcut name for the recorder.
 		/// Can be dynamically changed at any time.
@@ -67,10 +71,10 @@ extension KeyboardShortcuts {
 			}
 		}
 
-        /**
-         - Parameter name: Strongly-typed keyboard shortcut name.
-         - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-         */
+		/**
+		 - Parameter name: Strongly-typed keyboard shortcut name.
+		 - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+		 */
 		public required init(
 			for name: Name,
 			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil
@@ -89,7 +93,8 @@ extension KeyboardShortcuts {
 			self.translatesAutoresizingMaskIntoConstraints = false
 			setContentHuggingPriority(.defaultHigh, for: .vertical)
 			setContentHuggingPriority(.defaultLow, for: .horizontal)
-
+			self.isHorizontalContentSizeConstraintActive = true
+			
 			// Hide the cancel button when not showing the shortcut so the placeholder text is properly centered. Must be last.
 			self.cancelButton = (cell as? NSSearchFieldCell)?.cancelButtonCell
 
@@ -97,21 +102,6 @@ extension KeyboardShortcuts {
 
 			setUpEvents()
 		}
-        
-        /**
-         - Parameter name: Strongly-typed keyboard shortcut name.
-         - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-         - Parameter isHorizontalContentSizeConstraintActive: When `true`, makes sure to have width constraint set to avoid a cluttering placeholder string visibility. When `false`, the frame(:) modifier will control the actual width of the text field.
-         */
-        @available(macOS 10.15, *)
-        public convenience init(
-            for name: Name,
-            onChange: ((_ shortcut: Shortcut?) -> Void)? = nil,
-            isHorizontalContentSizeConstraintActive: Bool = false
-        ) {
-            self.init(for: name, onChange: onChange)
-            self.isHorizontalContentSizeConstraintActive = isHorizontalContentSizeConstraintActive
-        }
 
 		@available(*, unavailable)
 		public required init?(coder: NSCoder) {
@@ -152,11 +142,15 @@ extension KeyboardShortcuts {
 				focus()
 			}
 		}
-        
-        public func changeWidth(width: Double) {
-            self.intrinsicWidth = CGFloat(width)
-            invalidateIntrinsicContentSize()
-        }
+		
+		public func changeWidth(for size: NSControl.ControlSize) {
+			switch size {
+				case .small: self.intrinsicWidth = self.intrinsicWidthSmall
+				case .mini: self.intrinsicWidth = self.intrinsicWidthMini
+				default: self.intrinsicWidth = self.intrinsicWidthRegular
+			}
+			invalidateIntrinsicContentSize()
+		}
 
 		/// :nodoc:
 		public func controlTextDidEndEditing(_ object: Notification) {

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -26,7 +26,7 @@ extension KeyboardShortcuts {
 	```
 	*/
 	public final class RecorderCocoa: NSSearchField, NSSearchFieldDelegate {
-		private let minimumWidth: Double = 130
+		private var intrinsicWidth: CGFloat = 130
 		private var eventMonitor: LocalEventMonitor?
 		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
 		private var observer: NSObjectProtocol?
@@ -54,7 +54,7 @@ extension KeyboardShortcuts {
 		/// :nodoc:
 		override public var intrinsicContentSize: CGSize {
 			var size = super.intrinsicContentSize
-			size.width = CGFloat(minimumWidth)
+			size.width = intrinsicWidth
 			return size
 		}
 
@@ -67,13 +67,15 @@ extension KeyboardShortcuts {
 			}
 		}
 
-		/**
-		- Parameter name: Strongly-typed keyboard shortcut name.
-		- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-		*/
+        /**
+         - Parameter name: Strongly-typed keyboard shortcut name.
+         - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+         - Parameter isHorizontalContentSizeConstraintActive: When `true`, makes sure to have width constraint set to avoid cutting placeholder string. When `false`, the frame(:) modifier will control the actual width of the text field.
+         */
 		public required init(
 			for name: Name,
-			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil
+			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil,
+            isHorizontalContentSizeConstraintActive: Bool = false
 		) {
 			self.shortcutName = name
 			self.onChange = onChange
@@ -88,8 +90,8 @@ extension KeyboardShortcuts {
 			self.wantsLayer = true
 			self.translatesAutoresizingMaskIntoConstraints = false
 			setContentHuggingPriority(.defaultHigh, for: .vertical)
-			setContentHuggingPriority(.defaultHigh, for: .horizontal)
-			widthAnchor.constraint(greaterThanOrEqualToConstant: CGFloat(minimumWidth)).isActive = true
+			setContentHuggingPriority(.defaultLow, for: .horizontal)
+            self.isHorizontalContentSizeConstraintActive = isHorizontalContentSizeConstraintActive
 
 			// Hide the cancel button when not showing the shortcut so the placeholder text is properly centered. Must be last.
 			self.cancelButton = (cell as? NSSearchFieldCell)?.cancelButtonCell
@@ -138,6 +140,11 @@ extension KeyboardShortcuts {
 				focus()
 			}
 		}
+        
+        public func changeWidth(width: Double) {
+            self.intrinsicWidth = CGFloat(width)
+            invalidateIntrinsicContentSize()
+        }
 
 		/// :nodoc:
 		public func controlTextDidEndEditing(_ object: Notification) {


### PR DESCRIPTION
My current app design requires a smaller variant of the text field. Thus, I have implemented a proper support for controlSize(:) that (among others) reflects the font size to the controlSize parameter. Furthermore, changing the text field's width was an important requirements for proper layouting.

FYI: Please refer to the Previews in Recorder.swift for testings.