### PR TITLE
Add as SwiftUI `.keyboardShortcut()` helper

### DIFF
--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -300,8 +300,9 @@ extension KeyboardShortcuts.Shortcut: CustomStringConvertible {
 extension KeyboardShortcuts.Shortcut {
 	
 	@available(iOS 14.0, macOS 11.0, *)
-	var swiftUI: SwiftUI.KeyboardShortcut {
-		.init(.init(keyEquivalent.first!), modifiers: modifiers.swiftUI)
+	var swiftUI: SwiftUI.KeyboardShortcut? {
+		guard let key = keyEquivalent.first else { return nil }
+		return .init(.init(key), modifiers: modifiers.swiftUI)
 	}
 	
 }

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -298,55 +298,55 @@ extension KeyboardShortcuts.Shortcut: CustomStringConvertible {
 // MARK: - SwiftUI Helpers
 
 extension KeyboardShortcuts.Shortcut {
-  
-  @available(iOS 14.0, macOS 11.0, *)
-  var swiftUI: SwiftUI.KeyboardShortcut {
-    .init(.init(keyEquivalent.first!), modifiers: modifiers.swiftUI)
-  }
-
+	
+	@available(iOS 14.0, macOS 11.0, *)
+	var swiftUI: SwiftUI.KeyboardShortcut {
+		.init(.init(keyEquivalent.first!), modifiers: modifiers.swiftUI)
+	}
+	
 }
 
 @available(macOS 10.15, *)
 extension NSEvent.ModifierFlags {
-  var swiftUI: SwiftUI.EventModifiers {
-    var modifiers: SwiftUI.EventModifiers = []
-    if contains(.shift) {
-      modifiers.insert(.shift)
-    }
-    if contains(.command) {
-      modifiers.insert(.command)
-    }
-    if contains(.capsLock) {
-      modifiers.insert(.capsLock)
-    }
-    if contains(.function) {
-      modifiers.insert(.function)
-    }
-    if contains(.option) {
-      modifiers.insert(.option)
-    }
-    if contains(.control) {
-      modifiers.insert(.control)
-    }
-    return modifiers
-  }
+	var swiftUI: SwiftUI.EventModifiers {
+		var modifiers: SwiftUI.EventModifiers = []
+		if contains(.shift) {
+			modifiers.insert(.shift)
+		}
+		if contains(.command) {
+			modifiers.insert(.command)
+		}
+		if contains(.capsLock) {
+			modifiers.insert(.capsLock)
+		}
+		if contains(.function) {
+			modifiers.insert(.function)
+		}
+		if contains(.option) {
+			modifiers.insert(.option)
+		}
+		if contains(.control) {
+			modifiers.insert(.control)
+		}
+		return modifiers
+	}
 }
 
 @available(iOS 14.0, macOS 11.0, *)
 extension View {
-  
-  @ViewBuilder
-  /// Assigns the global keyboard shortcut to the modified control.
-  ///
-  /// Only assigns a keyboard shortcut, if one was defined (or it has a default shortcut).
-  ///
-  /// - Parameter shortcut: Strongly-typed name of the shortcut
-  public func keyboardShortcut(_ shortcut: KeyboardShortcuts.Name) -> some View {
-    if let shortcut = (shortcut.shortcut ?? shortcut.defaultShortcut)?.swiftUI {
-      self.keyboardShortcut(shortcut)
-    } else {
-      self
-    }
-  }
-  
+	
+	@ViewBuilder
+	/// Assigns the global keyboard shortcut to the modified control.
+	///
+	/// Only assigns a keyboard shortcut, if one was defined (or it has a default shortcut).
+	///
+	/// - Parameter shortcut: Strongly-typed name of the shortcut
+	public func keyboardShortcut(_ shortcut: KeyboardShortcuts.Name) -> some View {
+		if let shortcut = (shortcut.shortcut ?? shortcut.defaultShortcut)?.swiftUI {
+			self.keyboardShortcut(shortcut)
+		} else {
+			self
+		}
+	}
+	
 }

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -1,6 +1,8 @@
 import Cocoa
 import Carbon.HIToolbox
 
+import SwiftUI
+
 extension KeyboardShortcuts {
 	/**
 	A keyboard shortcut.
@@ -291,4 +293,60 @@ extension KeyboardShortcuts.Shortcut: CustomStringConvertible {
 	public var description: String {
 		modifiers.description + (keyToCharacter()?.uppercased() ?? "�")
 	}
+}
+
+// MARK: - SwiftUI Helpers
+
+extension KeyboardShortcuts.Shortcut {
+  
+  @available(iOS 14.0, macOS 11.0, *)
+  var swiftUI: SwiftUI.KeyboardShortcut {
+    .init(.init(keyEquivalent.first!), modifiers: modifiers.swiftUI)
+  }
+
+}
+
+@available(macOS 10.15, *)
+extension NSEvent.ModifierFlags {
+  var swiftUI: SwiftUI.EventModifiers {
+    var modifiers: SwiftUI.EventModifiers = []
+    if contains(.shift) {
+      modifiers.insert(.shift)
+    }
+    if contains(.command) {
+      modifiers.insert(.command)
+    }
+    if contains(.capsLock) {
+      modifiers.insert(.capsLock)
+    }
+    if contains(.function) {
+      modifiers.insert(.function)
+    }
+    if contains(.option) {
+      modifiers.insert(.option)
+    }
+    if contains(.control) {
+      modifiers.insert(.control)
+    }
+    return modifiers
+  }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+extension View {
+  
+  @ViewBuilder
+  /// Assigns the global keyboard shortcut to the modified control.
+  ///
+  /// Only assigns a keyboard shortcut, if one was defined (or it has a default shortcut).
+  ///
+  /// - Parameter shortcut: Strongly-typed name of the shortcut
+  public func keyboardShortcut(_ shortcut: KeyboardShortcuts.Name) -> some View {
+    if let shortcut = (shortcut.shortcut ?? shortcut.defaultShortcut)?.swiftUI {
+      self.keyboardShortcut(shortcut)
+    } else {
+      self
+    }
+  }
+  
 }


### PR DESCRIPTION
This adds a `.keyboardShortcut(_ shortcut: KeyboardShortcuts.Name)` helper function to assign a shortcut defined through this `KeyboardShortcuts` to a SwiftUI button. This provides a similar functionality to the existing `NSMenuItem` extension, but when using SwiftUI's `Commands` to define your menu items. 

This can be used as follows:

```swift
@main
struct MyApp: App {
  
  var body: some Scene {
    WindowGroup {
      ...
    }
    .commands {
      CommandMenu("Unicorns") {
        Button("Toggle Unicorn Mode") { ... }
        .keyboardShortcut(.toggleUnicornMode)
      }
    }
  }

}
```

In my testing on macOS 12 this works well without having to disable the global keyboard shortcut while the menu is visible, but I'm not really sure if it's safe to do so.