### PR TITLE
Automate DocC generation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,11 +1,7 @@
 name: Generate documentation
 on:
-  push:
-    branches:
-      - docc
-# on:
-#   release:
-#     types: [published]
+  release:
+    types: [published]
 jobs:
   deploy:
     runs-on: macos-12
@@ -23,4 +19,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: '.'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,26 @@
+name: Generate documentation
+on:
+  push:
+    branches:
+      - docc
+# on:
+#   release:
+#     types: [published]
+jobs:
+  deploy:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: DocC
+        run: >
+          swift package --allow-writing-to-directory docs
+          generate-documentation --target KeyboardShortcuts
+          --disable-indexing
+          --transform-for-static-hosting
+          --hosting-base-path KeyboardShortcuts
+          --output-path docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs


### PR DESCRIPTION
This is blocked by GitHub Actions getting macOS 12 support.

TODO:
- [x] update links to the docs
- [ ] remove nodocs comments
- [ ] find out if DocC has a way to hide properties
- [ ] Move readme docs to DocC


https://developer.apple.com/documentation/xcode/adding-structure-to-your-documentation-pages

https://developer.apple.com/documentation/xcode/adding-supplemental-content-to-a-documentation-catalog

https://developer.apple.com/documentation/xcode/formatting-your-documentation-content