### PR TITLE
Update localization zh-TW to align with Apple Localization Terms Glossary

### DIFF
--- a/Sources/KeyboardShortcuts/Localization/zh-TW.lproj/Localizable.strings
+++ b/Sources/KeyboardShortcuts/Localization/zh-TW.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-"record_shortcut" = "記錄快捷鍵";
-"press_shortcut" = "鍵入快捷鍵";
-"keyboard_shortcut_used_by_menu_item" = "此快捷鍵無法使用，因為它已被選單項目「%@」使用。";
-"keyboard_shortcut_used_by_system" = "此快捷鍵無法使用，因為它已是系統通用快捷鍵。";
-"keyboard_shortcuts_can_be_changed" = "可以在「系統偏好設定 › 鍵盤 › 快速鍵」中更改大多數的系統快捷鍵。";
+"record_shortcut" = "記錄快速鍵";
+"press_shortcut" = "按下快速鍵";
+"keyboard_shortcut_used_by_menu_item" = "此快速鍵無法使用，因為它已被選單項目「%@」使用。";
+"keyboard_shortcut_used_by_system" = "此快速鍵無法使用，因為它已是系統通用快速鍵。";
+"keyboard_shortcuts_can_be_changed" = "可以在「系統偏好設定 › 鍵盤 › 快速鍵」中更改大多數的系統快速鍵。";


### PR DESCRIPTION
Shortcut should be "快速鍵", rather than "快捷键", which is used in mainland China rather than Taiwan.

See here for reference: https://applelocalization.com/macos?q=keyboard+shortcut&l=English&l=Traditional+Chinese