### PR TITLE
View Modifier Implementations

### DIFF
--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -103,7 +103,7 @@ private struct DoubleShortcut: View {
 			.onKeyboardShortcut(.testShortcut1) {
 				isPressed1 = $0 == .keyDown
 			}
-			.onKeyboardShortcut(.testShortcut2, event: .keyDown) {
+			.onKeyboardShortcut(.testShortcut2, type: .keyDown) {
 				isPressed2 = true
 			}
 			.task {

--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -84,9 +84,6 @@ private struct DoubleShortcut: View {
 					Text("Pressed? \(isPressed1 ? "👍" : "👎")")
 						.offset(x: 90)
 				}
-				.onShortcutEvent(.testShortcut1) {
-					isPressed1 = $0 == .keyDown
-				}
 			KeyboardShortcuts.Recorder(for: .testShortcut2) {
 				Text("Shortcut 2:") // Intentionally using the verbose initializer for testing.
 			}
@@ -103,10 +100,13 @@ private struct DoubleShortcut: View {
 			.frame(maxWidth: 300)
 			.padding()
 			.padding()
+			.onKeyboardShortcut(.testShortcut1) {
+				isPressed1 = $0 == .keyDown
+			}
+			.onKeyboardShortcut(.testShortcut2, event: .keyDown) {
+				isPressed2 = true
+			}
 			.task {
-				KeyboardShortcuts.onKeyDown(for: .testShortcut2) {
-					isPressed2 = true
-				}
 				KeyboardShortcuts.onKeyUp(for: .testShortcut2) {
 					isPressed2 = false
 				}

--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -84,6 +84,9 @@ private struct DoubleShortcut: View {
 					Text("Pressed? \(isPressed1 ? "👍" : "👎")")
 						.offset(x: 90)
 				}
+				.onShortcutEvent(.testShortcut1) {
+					isPressed1 = $0 == .keyDown
+				}
 			KeyboardShortcuts.Recorder(for: .testShortcut2) {
 				Text("Shortcut 2:") // Intentionally using the verbose initializer for testing.
 			}
@@ -101,21 +104,11 @@ private struct DoubleShortcut: View {
 			.padding()
 			.padding()
 			.task {
-				KeyboardShortcuts.onKeyDown(for: .testShortcut1) {
-					isPressed1 = true
-				}
-
 				KeyboardShortcuts.onKeyDown(for: .testShortcut2) {
 					isPressed2 = true
 				}
-
 				KeyboardShortcuts.onKeyUp(for: .testShortcut2) {
 					isPressed2 = false
-				}
-			}
-			.task {
-				for await _ in KeyboardShortcuts.on(.keyUp, for: .testShortcut1) {
-					isPressed1 = false
 				}
 			}
 	}

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -415,6 +415,7 @@ extension KeyboardShortcuts {
 				streamKeyDownHandlers[name, default: [:]][id] = {
 					continuation.yield(.keyDown)
 				}
+
 				streamKeyUpHandlers[name, default: [:]][id] = {
 					continuation.yield(.keyUp)
 				}
@@ -466,7 +467,7 @@ extension KeyboardShortcuts {
 	public static func events(_ type: EventType, for name: Name) -> AsyncFilterSequence<AsyncStream<EventType>> {
 		events(for: name).filter { $0 == type }
 	}
-	
+
 	@available(macOS 10.15, *)
 	@available(*, deprecated, renamed: "events(_:for:)")
 	public static func on(_ type: EventType, for name: Name) -> AsyncStream<Void> {

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -411,20 +411,24 @@ extension KeyboardShortcuts {
 		AsyncStream { continuation in
 			let id = UUID()
 
-			streamKeyDownHandlers[name, default: [:]][id] = {
-				continuation.yield(.keyDown)
-			}
-			streamKeyUpHandlers[name, default: [:]][id] = {
-				continuation.yield(.keyUp)
-			}
+			DispatchQueue.main.async {
+				streamKeyDownHandlers[name, default: [:]][id] = {
+					continuation.yield(.keyDown)
+				}
+				streamKeyUpHandlers[name, default: [:]][id] = {
+					continuation.yield(.keyUp)
+				}
 
-			registerShortcutIfNeeded(for: name)
+				registerShortcutIfNeeded(for: name)
+			}
 
 			continuation.onTermination = { _ in
-				streamKeyDownHandlers[name]?[id] = nil
-				streamKeyUpHandlers[name]?[id] = nil
+				DispatchQueue.main.async {
+					streamKeyDownHandlers[name]?[id] = nil
+					streamKeyUpHandlers[name]?[id] = nil
 
-				unregisterShortcutIfNeeded(for: name)
+					unregisterShortcutIfNeeded(for: name)
+				}
 			}
 		}
 	}

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -429,6 +429,35 @@ extension KeyboardShortcuts {
 		}
 	}
 
+	/**
+	Listen to keyboard shortcut events with the given name and type.
+
+	You can register multiple listeners.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	Ending the async sequence will stop the listener. For example, in the below example, the listener will stop when the view disappears.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct ContentView: View {
+		@State private var isUnicornMode = false
+
+		var body: some View {
+			Text(isUnicornMode ? "🦄" : "🐴")
+				.task {
+					for await event in KeyboardShortcuts.events(for: .toggleUnicornMode) where event == .keyUp {
+						isUnicornMode.toggle()
+					}
+				}
+		}
+	}
+	```
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
 	@available(macOS 10.15, *)
 	public static func events(_ type: EventType, for name: Name) -> AsyncFilterSequence<AsyncStream<EventType>> {
 		events(for: name).filter { $0 == type }

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -430,7 +430,12 @@ extension KeyboardShortcuts {
 	}
 
 	@available(macOS 10.15, *)
-	@available(*, deprecated, message: "Use events(for:) instead")
+	public static func events(for name: Name, type: EventType) -> AsyncFilterSequence<AsyncStream<EventType>> {
+		events(for: name).filter { $0 == type }
+	}
+
+	@available(macOS 10.15, *)
+	@available(*, deprecated, renamed: "events(for:type:)")
 	public static func on(_ type: EventType, for name: Name) -> AsyncStream<Void> {
 		AsyncStream { continuation in
 			let id = UUID()

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -430,12 +430,12 @@ extension KeyboardShortcuts {
 	}
 
 	@available(macOS 10.15, *)
-	public static func events(for name: Name, type: EventType) -> AsyncFilterSequence<AsyncStream<EventType>> {
+	public static func events(_ type: EventType, for name: Name) -> AsyncFilterSequence<AsyncStream<EventType>> {
 		events(for: name).filter { $0 == type }
 	}
-
+	
 	@available(macOS 10.15, *)
-	@available(*, deprecated, renamed: "events(for:type:)")
+	@available(*, deprecated, renamed: "events(_:for:)")
 	public static func on(_ type: EventType, for name: Name) -> AsyncStream<Void> {
 		AsyncStream { continuation in
 			let id = UUID()

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -396,7 +396,7 @@ extension KeyboardShortcuts {
 		var body: some View {
 			Text(isUnicornMode ? "🦄" : "🐴")
 				.task {
-					for await _ in KeyboardShortcuts.on(.keyUp, for: .toggleUnicornMode) {
+					for await event in KeyboardShortcuts.events(for: .toggleUnicornMode) where event == .keyUp {
 						isUnicornMode.toggle()
 					}
 				}
@@ -407,6 +407,30 @@ extension KeyboardShortcuts {
 	- Note: This method is not affected by `.removeAllHandlers()`.
 	*/
 	@available(macOS 10.15, *)
+	public static func events(for name: Name) -> AsyncStream<KeyboardShortcuts.EventType> {
+		AsyncStream { continuation in
+			let id = UUID()
+
+			streamKeyDownHandlers[name, default: [:]][id] = {
+				continuation.yield(.keyDown)
+			}
+			streamKeyUpHandlers[name, default: [:]][id] = {
+				continuation.yield(.keyUp)
+			}
+
+			registerShortcutIfNeeded(for: name)
+
+			continuation.onTermination = { _ in
+				streamKeyDownHandlers[name]?[id] = nil
+				streamKeyUpHandlers[name]?[id] = nil
+
+				unregisterShortcutIfNeeded(for: name)
+			}
+		}
+	}
+
+	@available(macOS 10.15, *)
+	@available(*, deprecated, message: "Use events(for:) instead")
 	public static func on(_ type: EventType, for name: Name) -> AsyncStream<Void> {
 		AsyncStream { continuation in
 			let id = UUID()

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -12,7 +12,7 @@ extension View {
 
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, type: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
 		task {
-			for await eventType in KeyboardShortcuts.events(for: shortcut) where eventType == type {
+			for await _ in KeyboardShortcuts.events(for: shortcut, type: type) {
 				perform()
 			}
 		}

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -12,7 +12,7 @@ extension View {
 
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, type: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
 		task {
-			for await _ in KeyboardShortcuts.events(for: shortcut, type: type) {
+			for await _ in KeyboardShortcuts.events(type, for: shortcut) {
 				perform()
 			}
 		}

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -3,25 +3,18 @@ import SwiftUI
 @available(macOS 12, *)
 extension View {
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, perform: @escaping (KeyboardShortcuts.EventType) -> Void) -> some View {
-		self
-			.task {
-				for await _ in KeyboardShortcuts.on(.keyDown, for: shortcut) {
-					perform(.keyDown)
-				}
+		task {
+			for await event in KeyboardShortcuts.events(for: shortcut) {
+				perform(event)
 			}
-			.task {
-				for await _ in KeyboardShortcuts.on(.keyUp, for: shortcut) {
-					perform(.keyUp)
-				}
-			}
+		}
 	}
 
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, event: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
-		self
-			.task {
-				for await _ in KeyboardShortcuts.on(event, for: shortcut) {
-					perform()
-				}
+		task {
+			for await shortcutEvent in KeyboardShortcuts.events(for: shortcut) where shortcutEvent == event {
+				perform()
 			}
+		}
 	}
 }

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+@available(macOS 12, *)
+extension View {
+	public func onShortcutEvent(_ shortcut: KeyboardShortcuts.Name, perform: @escaping (KeyboardShortcuts.EventType) -> Void) -> some View {
+		let shortcutModifier = ShortcutViewModifier(shortcut: shortcut, perform: perform)
+		return modifier(shortcutModifier)
+	}
+
+	public func onShortcutUp(_ shortcut: KeyboardShortcuts.Name, perform: @escaping () -> Void) -> some View {
+		let shortcutModifier = ShortcutEventViewModifier(shortcut: shortcut, event: .keyUp, perform: perform)
+		return modifier(shortcutModifier)
+	}
+
+	public func onShortcutDown(_ shortcut: KeyboardShortcuts.Name, perform: @escaping () -> Void) -> some View {
+		let shortcutModifier = ShortcutEventViewModifier(shortcut: shortcut, event: .keyDown, perform: perform)
+		return modifier(shortcutModifier)
+	}
+}
+
+@available(macOS 12, *)
+struct ShortcutEventViewModifier: ViewModifier {
+	let shortcut: KeyboardShortcuts.Name
+	let event: KeyboardShortcuts.EventType
+	let perform: () -> Void
+
+	func body(content: Content) -> some View {
+		content
+			.task {
+				for await _ in KeyboardShortcuts.on(event, for: shortcut) {
+					perform()
+				}
+			}
+	}
+}
+
+@available(macOS 12, *)
+struct ShortcutViewModifier: ViewModifier {
+	let shortcut: KeyboardShortcuts.Name
+	let perform: (KeyboardShortcuts.EventType) -> Void
+
+	func body(content: Content) -> some View {
+		content
+			.task {
+				for await _ in KeyboardShortcuts.on(.keyDown, for: shortcut) {
+					perform(.keyDown)
+				}
+			}
+			.task {
+				for await _ in KeyboardShortcuts.on(.keyUp, for: shortcut) {
+					perform(.keyUp)
+				}
+			}
+	}
+}

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -10,9 +10,9 @@ extension View {
 		}
 	}
 
-	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, event: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
+	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, type: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
 		task {
-			for await shortcutEvent in KeyboardShortcuts.events(for: shortcut) where shortcutEvent == event {
+			for await eventType in KeyboardShortcuts.events(for: shortcut) where eventType == type {
 				perform()
 			}
 		}

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -13,8 +13,8 @@ extension View {
 	*/
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, perform: @escaping (KeyboardShortcuts.EventType) -> Void) -> some View {
 		task {
-			for await event in KeyboardShortcuts.events(for: shortcut) {
-				perform(event)
+			for await eventType in KeyboardShortcuts.events(for: shortcut) {
+				perform(eventType)
 			}
 		}
 	}

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -2,6 +2,15 @@ import SwiftUI
 
 @available(macOS 12, *)
 extension View {
+	/**
+	Register a listener for keyboard shortcut events with the given name.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	The listener will stop automatically when the view disappears.
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, perform: @escaping (KeyboardShortcuts.EventType) -> Void) -> some View {
 		task {
 			for await event in KeyboardShortcuts.events(for: shortcut) {
@@ -10,6 +19,15 @@ extension View {
 		}
 	}
 
+	/**
+	Register a listener for keyboard shortcut events with the given name and type.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	The listener will stop automatically when the view disappears.
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
 	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, type: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
 		task {
 			for await _ in KeyboardShortcuts.events(type, for: shortcut) {

--- a/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -2,45 +2,8 @@ import SwiftUI
 
 @available(macOS 12, *)
 extension View {
-	public func onShortcutEvent(_ shortcut: KeyboardShortcuts.Name, perform: @escaping (KeyboardShortcuts.EventType) -> Void) -> some View {
-		let shortcutModifier = ShortcutViewModifier(shortcut: shortcut, perform: perform)
-		return modifier(shortcutModifier)
-	}
-
-	public func onShortcutUp(_ shortcut: KeyboardShortcuts.Name, perform: @escaping () -> Void) -> some View {
-		let shortcutModifier = ShortcutEventViewModifier(shortcut: shortcut, event: .keyUp, perform: perform)
-		return modifier(shortcutModifier)
-	}
-
-	public func onShortcutDown(_ shortcut: KeyboardShortcuts.Name, perform: @escaping () -> Void) -> some View {
-		let shortcutModifier = ShortcutEventViewModifier(shortcut: shortcut, event: .keyDown, perform: perform)
-		return modifier(shortcutModifier)
-	}
-}
-
-@available(macOS 12, *)
-struct ShortcutEventViewModifier: ViewModifier {
-	let shortcut: KeyboardShortcuts.Name
-	let event: KeyboardShortcuts.EventType
-	let perform: () -> Void
-
-	func body(content: Content) -> some View {
-		content
-			.task {
-				for await _ in KeyboardShortcuts.on(event, for: shortcut) {
-					perform()
-				}
-			}
-	}
-}
-
-@available(macOS 12, *)
-struct ShortcutViewModifier: ViewModifier {
-	let shortcut: KeyboardShortcuts.Name
-	let perform: (KeyboardShortcuts.EventType) -> Void
-
-	func body(content: Content) -> some View {
-		content
+	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, perform: @escaping (KeyboardShortcuts.EventType) -> Void) -> some View {
+		self
 			.task {
 				for await _ in KeyboardShortcuts.on(.keyDown, for: shortcut) {
 					perform(.keyDown)
@@ -49,6 +12,15 @@ struct ShortcutViewModifier: ViewModifier {
 			.task {
 				for await _ in KeyboardShortcuts.on(.keyUp, for: shortcut) {
 					perform(.keyUp)
+				}
+			}
+	}
+
+	public func onKeyboardShortcut(_ shortcut: KeyboardShortcuts.Name, event: KeyboardShortcuts.EventType, perform: @escaping () -> Void) -> some View {
+		self
+			.task {
+				for await _ in KeyboardShortcuts.on(event, for: shortcut) {
+					perform()
 				}
 			}
 	}


### PR DESCRIPTION
@sindresorhus I added an implementation using ViewModifiers to more closely match the syntax.

I'm not super sure about the API design, because I don't love the name of the functions. Maybe keeping only the implementation of `onShortcutEvent` but renamed to `onShortcut` would look cleaner.