### PR TITLE
Fix compatibility with `View#focused()`

### DIFF
--- a/Example/KeyboardShortcutsExample.xcodeproj/project.pbxproj
+++ b/Example/KeyboardShortcutsExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 				};
 			};
 			buildConfigurationList = E36FB9412609BA43004272D9 /* Build configuration list for PBXProject "KeyboardShortcutsExample" */;
-			compatibilityVersion = "Xcode 12.0";
+			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -222,7 +222,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -277,7 +277,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;

--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -9,15 +9,23 @@ extension KeyboardShortcuts.Name {
 }
 
 private struct DynamicShortcutRecorder: View {
+	@FocusState private var isFocused: Bool
+
 	@Binding var name: KeyboardShortcuts.Name
 	@Binding var isPressed: Bool
 
 	var body: some View {
 		HStack(alignment: .firstTextBaseline) {
 			KeyboardShortcuts.Recorder(for: name)
+				.focused($isFocused)
 				.padding(.trailing, 10)
 			Text("Pressed? \(isPressed ? "👍" : "👎")")
 				.frame(width: 100, alignment: .leading)
+		}
+		.onChange(of: name) { _ in
+			DispatchQueue.main.async {
+				isFocused = true
+			}
 		}
 	}
 }

--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -22,11 +22,9 @@ private struct DynamicShortcutRecorder: View {
 			Text("Pressed? \(isPressed ? "👍" : "👎")")
 				.frame(width: 100, alignment: .leading)
 		}
-		.onChange(of: name) { _ in
-			DispatchQueue.main.async {
+			.onChange(of: name) { _ in
 				isFocused = true
 			}
-		}
 	}
 }
 

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -45,9 +45,12 @@ extension KeyboardShortcuts {
 
 				setStringValue(name: shortcutName)
 
-				DispatchQueue.main.async { [self] in
-					// Prevents the placeholder from being cut off.
-					blur()
+				// This doesn't seem to be needed anymore, but I cannot test on older OS versions, so keeping it just in case.
+				if #unavailable(macOS 12) {
+					DispatchQueue.main.async { [self] in
+						// Prevents the placeholder from being cut off.
+						blur()
+					}
 				}
 			}
 		}
@@ -157,9 +160,7 @@ extension KeyboardShortcuts {
 				return
 			}
 
-			DispatchQueue.main.async { [self] in
-				canBecomeKey = true
-			}
+			canBecomeKey = true
 		}
 
 		/// :nodoc:

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -30,6 +30,7 @@ extension KeyboardShortcuts {
 		private var eventMonitor: LocalEventMonitor?
 		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
 		private var observer: NSObjectProtocol?
+		private var canBecomeKey = false
 
 		/**
 		The shortcut name for the recorder.
@@ -52,7 +53,7 @@ extension KeyboardShortcuts {
 		}
 
 		/// :nodoc:
-		override public var canBecomeKeyView: Bool { false }
+		override public var canBecomeKeyView: Bool { canBecomeKey }
 
 		/// :nodoc:
 		override public var intrinsicContentSize: CGSize {
@@ -147,6 +148,18 @@ extension KeyboardShortcuts {
 			placeholderString = "record_shortcut".localized
 			showsCancelButton = !stringValue.isEmpty
 			KeyboardShortcuts.isPaused = false
+		}
+
+		// Prevent the control from receiving the initial focus.
+		/// :nodoc:
+		override public func viewDidMoveToWindow() {
+			guard window != nil else {
+				return
+			}
+
+			DispatchQueue.main.async { [self] in
+				canBecomeKey = true
+			}
 		}
 
 		/// :nodoc:


### PR DESCRIPTION
Fixes #76

@godbout The problem was that the recorder needs to prevent initial focus, otherwise it would enter the key recording when the window shows. I previously solved this by preventing it from becoming a key view. That's what prevented focus.

I'm not really happy with what's in this pull request, but it's the best I could come up with. I'm open to other ideas. I'm also concerned it may break some usage, although it worked fine in the example app and my Dato app.

You also need a dispatch call on before setting the focus. I think that's a SwiftUI bug and unrelated to this.

Could you try out this pull request in your app?