### PR TITLE
Fix duplication checking for shortcuts with a shift key.

### DIFF
--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -112,12 +112,20 @@ extension KeyboardShortcuts.Shortcut {
 	*/
 	func menuItemWithMatchingShortcut(in menu: NSMenu) -> NSMenuItem? {
 		for item in menu.items {
-			if
-				keyToCharacter() == item.keyEquivalent,
-				modifiers == item.keyEquivalentModifierMask
-			{
-				return item
-			}
+            var keyEquivalent = item.keyEquivalent
+            var keyEquivalentModifierMask = item.keyEquivalentModifierMask
+            
+            if modifiers.contains(.shift) {
+                keyEquivalent = keyEquivalent.lowercased()
+                keyEquivalentModifierMask.insert(.shift)
+            }
+            
+            if
+                keyToCharacter() == keyEquivalent,
+                modifiers == keyEquivalentModifierMask
+            {
+                return item
+            }
 
 			if
 				let submenu = item.submenu,

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -112,20 +112,20 @@ extension KeyboardShortcuts.Shortcut {
 	*/
 	func menuItemWithMatchingShortcut(in menu: NSMenu) -> NSMenuItem? {
 		for item in menu.items {
-            var keyEquivalent = item.keyEquivalent
-            var keyEquivalentModifierMask = item.keyEquivalentModifierMask
-            
-            if modifiers.contains(.shift) {
-                keyEquivalent = keyEquivalent.lowercased()
-                keyEquivalentModifierMask.insert(.shift)
-            }
-            
-            if
-                keyToCharacter() == keyEquivalent,
-                modifiers == keyEquivalentModifierMask
-            {
-                return item
-            }
+			var keyEquivalent = item.keyEquivalent
+			var keyEquivalentModifierMask = item.keyEquivalentModifierMask
+
+			if modifiers.contains(.shift) {
+				keyEquivalent = keyEquivalent.lowercased()
+				keyEquivalentModifierMask.insert(.shift)
+			}
+
+			if
+				keyToCharacter() == keyEquivalent,
+				modifiers == keyEquivalentModifierMask
+			{
+				return item
+			}
 
 			if
 				let submenu = item.submenu,


### PR DESCRIPTION
Try to fix shortcuts with a shift key that can not be matched by the duplication check.

Like Command+Shift+P.
If you have a menu item using this shortcut, then you tried to set the same shortcut in KeyboardShorts. The duplication check won't show any alert. Because:

For the shortcut you want to set:
keyToCharacter() = "p"
modifiers = [.shift, .command]

For the menu item:
keyEquivalent = "P"
keyEquivalentModifierMask = [.command]

They represent this shortcut in a different way. So I did this quick fix. Hope it helps.
