### PR TITLE
Fix documentation link (case-sensitive)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ This package supports [localizations](/Sources/KeyboardShortcuts/Localization). 
 
 ## API
 
-[See the API docs.](https://swiftpackageindex.com/sindresorhus/keyboardshortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts)
+[See the API docs.](https://swiftpackageindex.com/sindresorhus/KeyboardShortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts)
 
 ## Tips
 


### PR DESCRIPTION
This seems to be an issue with `swiftpackageindex.com`. The lowercase link does not work when linking directly to the page, but it does work when you navigate from their website.

Before, shows "Documentation Error"

```
$ curl -o - -I https://swiftpackageindex.com/sindresorhus/keyboardshortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts
HTTP/2 404 
```

[https://swiftpackageindex.com/sindresorhus/**k**eyboard**s**hortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts](https://swiftpackageindex.com/sindresorhus/keyboardshortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts)

After

```
$ curl -o - -I https://swiftpackageindex.com/sindresorhus/KeyboardShortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts
HTTP/2 200 
```

[https://swiftpackageindex.com/sindresorhus/**K**eyboard**S**hortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts](https://swiftpackageindex.com/sindresorhus/KeyboardShortcuts/main/documentation/keyboardshortcuts/keyboardshortcuts)