### PR TITLE
Registering / Enabling shortcuts now returns a @discardable Bool to know whether it worked or not

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -37,18 +37,22 @@ public enum KeyboardShortcuts {
 	*/
 	static var isPaused = false
 
-	private static func register(_ shortcut: Shortcut) {
+	@discardableResult private static func register(_ shortcut: Shortcut) -> Bool {
 		guard !registeredShortcuts.contains(shortcut) else {
-			return
+			return true //already registered
 		}
 
-		CarbonKeyboardShortcuts.register(
+		let keyboardShortcutRegistered = CarbonKeyboardShortcuts.register(
 			shortcut,
 			onKeyDown: handleOnKeyDown,
 			onKeyUp: handleOnKeyUp
 		)
 
+		guard keyboardShortcutRegistered else { return false }
+		
 		registeredShortcuts.insert(shortcut)
+		
+		return true
 	}
 
 	/**
@@ -129,12 +133,19 @@ public enum KeyboardShortcuts {
 	/**
 	Enable a disabled keyboard shortcut.
 	*/
-	public static func enable(_ name: Name) {
+	@discardableResult public static func enable(_ name: Name) -> Bool {
 		guard let shortcut = getShortcut(for: name) else {
-			return
+			return false
 		}
 
-		register(shortcut)
+		return register(shortcut)
+	}
+	
+	/**
+	 Returns whether the passed-in shortcut is currently registered.
+	 */
+	public static func shortcutIsEnabled(_ shortcut: Shortcut) -> Bool {
+		return registeredShortcuts.contains(shortcut) || registeredShortcuts.first(where: {$0.key == shortcut.key && $0.modifiers == shortcut.modifiers}) != nil
 	}
 
 	/**

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -38,6 +38,13 @@ extension KeyboardShortcuts {
 		You most likely don't need this.
 		*/
 		public let carbonModifiers: Int
+		
+		/**
+		 Returns whether this shortcut is registered/enabled.
+		 */
+		public var isEnabled: Bool {
+			KeyboardShortcuts.shortcutIsEnabled(self)
+		}
 
 		/**
 		Initialize from a strongly-typed key and modifiers.
@@ -97,7 +104,7 @@ extension KeyboardShortcuts.Shortcut {
 	/**
 	Check whether the keyboard shortcut is already taken by the system.
 	*/
-	var isTakenBySystem: Bool {
+	public var isTakenBySystem: Bool {
 		guard self != Self(.f12, modifiers: []) else {
 			return false
 		}


### PR DESCRIPTION
Also adds an "isEnabled" calculated property to Shortcut, and the appropriate .shortcutIsEnabled(_ : ) function to KeyboardShortcuts.

Makes var isTakenBySystem public so it can be used for "default" shortcuts created by an app, which makes us able to provide alternatives on startup.


This is non-breaking.

===
I squashed the 4 local commits beforehand, but I'm not sure if it worked, this is my first pull request on GitHub. It still shows me 4 commits instead of one.