### PR TITLE
Fix layout in NSPopover

### DIFF
--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -65,6 +65,13 @@ extension KeyboardShortcuts {
 			return size
 		}
 
+		public override func sizeThatFits(_ size: NSSize) -> NSSize {
+			var result = size
+			result.width = max(minimumWidth, result.width)
+
+			return result
+		}
+
 		private var cancelButton: NSButtonCell?
 
 		private var showsCancelButton: Bool {
@@ -92,10 +99,8 @@ extension KeyboardShortcuts {
 			(cell as? NSSearchFieldCell)?.searchButtonCell = nil
 
 			self.wantsLayer = true
-			self.translatesAutoresizingMaskIntoConstraints = false
 			setContentHuggingPriority(.defaultHigh, for: .vertical)
 			setContentHuggingPriority(.defaultHigh, for: .horizontal)
-			widthAnchor.constraint(greaterThanOrEqualToConstant: minimumWidth).isActive = true
 
 			// Hide the cancel button when not showing the shortcut so the placeholder text is properly centered. Must be last.
 			self.cancelButton = (cell as? NSSearchFieldCell)?.cancelButtonCell


### PR DESCRIPTION
This maintains the `minimumWidth` by overriding `sizeThatFits(:)` instead of using Auto Layout. It appears that one of the implicit constraints disabled by `self.translatesAutoresizingMaskIntoConstraints` is critical for the `NSPopover` to maintain its position.

Fixes #75, https://github.com/bnidevs/Captura/issues/2.