### PR TITLE
Update RecorderCocoa.swift such that the user can click other buttons within the same window.

### DIFF
--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -189,7 +189,7 @@ extension KeyboardShortcuts {
 					!self.bounds.insetBy(dx: -clickMargin, dy: -clickMargin).contains(clickPoint)
 				{
 					self.blur()
-					return nil
+					return event
 				}
 
 				guard event.isKeyEvent else {


### PR DESCRIPTION
Return {event} instead of {nil} when the user clicks outside the RecorderCocoa field to allow any buttons, radio buttons and other controls, in the same UI as Recorder, to receive mouse input, or else it will take 3 mouse clicks to finally be able to press any button on the interface!