### PR TITLE
userDefaultsRemove uses removeObject

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -205,12 +205,15 @@ public enum KeyboardShortcuts {
 	You would usually not need this as the user would be the one setting the shortcut in a settings user-interface, but it can be useful when, for example, migrating from a different keyboard shortcuts package.
 	*/
 	public static func setShortcut(_ shortcut: Shortcut?, for name: Name) {
-		guard let shortcut else {
-			userDefaultsRemove(name: name)
-			return
+		if let shortcut {
+			userDefaultsSet(name: name, shortcut: shortcut)
+		} else {
+			if name.defaultShortcut != nil {
+				userDefaultsDisable(name: name)
+			} else {
+				userDefaultsRemove(name: name)
+			}
 		}
-
-		userDefaultsSet(name: name, shortcut: shortcut)
 	}
 
 	/**
@@ -352,6 +355,16 @@ public enum KeyboardShortcuts {
 
 		register(shortcut)
 		UserDefaults.standard.set(encoded, forKey: userDefaultsKey(for: name))
+		userDefaultsDidChange(name: name)
+	}
+
+	static func userDefaultsDisable(name: Name) {
+		guard let shortcut = getShortcut(for: name) else {
+			return
+		}
+
+		UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
+		unregister(shortcut)
 		userDefaultsDidChange(name: name)
 	}
 

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -360,7 +360,7 @@ public enum KeyboardShortcuts {
 			return
 		}
 
-		UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
+		UserDefaults.standard.removeObject(forKey: userDefaultsKey(for: name))
 		unregister(shortcut)
 		userDefaultsDidChange(name: name)
 	}


### PR DESCRIPTION
At present `userDefaultsRemove` is setting the value to false.
For my specifc case, where a lot of dynamic keys are used, I noticed a lot of stale keys in UserDefaults. I think it's best to remove the key