### PR TITLE
Fix: cursor disappear when switching to other textfield

### DIFF
--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -148,6 +148,7 @@ extension KeyboardShortcuts {
 			eventMonitor = nil
 			placeholderString = "record_shortcut".localized
 			showsCancelButton = !stringValue.isEmpty
+            restoreCaret()
 			KeyboardShortcuts.isPaused = false
 		}
 

--- a/Sources/KeyboardShortcuts/Utilities.swift
+++ b/Sources/KeyboardShortcuts/Utilities.swift
@@ -26,6 +26,10 @@ extension NSTextField {
 	func hideCaret() {
 		(currentEditor() as? NSTextView)?.insertionPointColor = .clear
 	}
+
+    func restoreCaret() {
+        (currentEditor() as? NSTextView)?.insertionPointColor = .labelColor
+    }
 }
 
 


### PR DESCRIPTION
When there are RecorderCocoa and TextFields in the same view controller, cursor disappears when switching from RecorderCocoa  to other TextFields.
It seems that only RecorderCocoa has this issue, SwiftUI works well.