### PR TITLE
Custom storage for shortcuts

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -285,7 +285,11 @@ public enum KeyboardShortcuts {
         if let shortcut {
             storageProviderSet(name: name, shortcut: shortcut)
         } else {
-            storageProviderRemove(name: name)
+            if name.defaultShortcut != nil {
+                storageProviderDisable(name: name)
+            } else {
+                storageProviderRemove(name: name)
+            }
         }
 	}
 

--- a/Sources/KeyboardShortcuts/Name.swift
+++ b/Sources/KeyboardShortcuts/Name.swift
@@ -40,7 +40,7 @@ extension KeyboardShortcuts {
             
             if
                 let initialShortcut,
-                !storageProviderContains(name: self) // TODO: Make this use storage if set
+                !storageProviderContains(name: self)
             {
                 setShortcut(initialShortcut, for: self)
             }

--- a/Sources/KeyboardShortcuts/Name.swift
+++ b/Sources/KeyboardShortcuts/Name.swift
@@ -34,18 +34,18 @@ extension KeyboardShortcuts {
 		- Parameter name: Name of the shortcut.
 		- Parameter default: Optional default key combination. Do not set this unless it's essential. Users find it annoying when random apps steal their existing keyboard shortcuts. It's generally better to show a welcome screen on the first app launch that lets the user set the shortcut.
 		*/
-		public init(_ name: String, default initialShortcut: Shortcut? = nil) {
+        public init(_ name: String, default initialShortcut: Shortcut? = nil) {
 			self.rawValue = name
 			self.defaultShortcut = initialShortcut
+            
+            if
+                let initialShortcut,
+                !storageProviderContains(name: self) // TODO: Make this use storage if set
+            {
+                setShortcut(initialShortcut, for: self)
+            }
 
-			if
-				let initialShortcut,
-				!userDefaultsContains(name: self)
-			{
-				setShortcut(initialShortcut, for: self)
-			}
-
-			KeyboardShortcuts.initialize()
+            KeyboardShortcuts.initialize()
 		}
 	}
 }
@@ -56,3 +56,5 @@ extension KeyboardShortcuts.Name: RawRepresentable {
 		self.init(rawValue)
 	}
 }
+
+

--- a/Sources/KeyboardShortcuts/Storage.swift
+++ b/Sources/KeyboardShortcuts/Storage.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol StorageProvider {
+    func get(forKey defaultName: String) -> String?
+    mutating func set(_ value: String?, forKey defaultName: String)
+    mutating func disable(forKey defaultName: String)
+    mutating func remove(forKey defaultName: String)
+    func contains(forKey defaultName: String) -> Bool
+}


### PR DESCRIPTION
Related to https://github.com/sindresorhus/KeyboardShortcuts/issues/18, I've tried to implement a protocol to allow for custom storage implementations. It still defaults to using UserDefaults unless anything else has been specified before running `KeyboardShortcuts.initialize()`.

You can consider this WIP, since it would probably be nice to add more tests etc, and documentation with examples how to use it. 