### PR TITLE
Fixed memory leak in case of NSMenuItem.

### DIFF
--- a/Sources/KeyboardShortcuts/NSMenuItem++.swift
+++ b/Sources/KeyboardShortcuts/NSMenuItem++.swift
@@ -46,6 +46,7 @@ extension NSMenuItem {
 	public func setShortcut(for name: KeyboardShortcuts.Name?) {
 		guard let name else {
 			clearShortcut()
+            NotificationCenter.default.removeObserver(AssociatedKeys.observer[self] as Any)
 			AssociatedKeys.observer[self] = nil
 			return
 		}


### PR DESCRIPTION
NSMenuItem has been leaked after calling `setShortcuts` and `KeyboardShortcuts.removeAllHandlers`.

The leak is caused by a callback function registered in the notification center that captures an NSMenuItem.
I added the code to remove NSMenuItem from notification center explicitly in case of calling `setShortcut(nil)` to get around this issue.