### PR TITLE
Add LocalizedStringKey initializer to Recorder to support localizing the title

### DIFF
--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -114,7 +114,7 @@ extension KeyboardShortcuts.Recorder<Text> {
 	- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
 	*/
 	public init(
-		_ title: String,
+		_ title: LocalizedStringKey,
 		name: KeyboardShortcuts.Name,
 		onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
 	) {
@@ -126,6 +126,29 @@ extension KeyboardShortcuts.Recorder<Text> {
 			Text(title)
 		}
 	}
+}
+
+@available(macOS 10.15, *)
+extension KeyboardShortcuts.Recorder<Text> {
+  /**
+  - Parameter title: The title of the keyboard shortcut recorder, describing its purpose.
+  - Parameter name: Strongly-typed keyboard shortcut name.
+  - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+  */
+  @_disfavoredOverload
+  public init<S>(
+    _ title: S,
+    name: KeyboardShortcuts.Name,
+    onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+  ) where S : StringProtocol {
+    self.init(
+      for: name,
+      onChange: onChange,
+      hasLabel: true
+    ) {
+      Text(title)
+    }
+  }
 }
 
 @available(macOS 10.15, *)

--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -174,18 +174,18 @@ extension KeyboardShortcuts.Recorder {
 
 @available(macOS 10.15, *)
 #Preview {
-	KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+	KeyboardShortcuts.Recorder("record_shortcut", name: .init("xcodePreview"))
 		.environment(\.locale, .init(identifier: "en"))
 }
 
 @available(macOS 10.15, *)
 #Preview {
-	KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+	KeyboardShortcuts.Recorder("record_shortcut", name: .init("xcodePreview"))
 		.environment(\.locale, .init(identifier: "zh-Hans"))
 }
 @available(macOS 10.15, *)
 #Preview {
-	KeyboardShortcuts.Recorder(for: .init("xcodePreview"))
+	KeyboardShortcuts.Recorder("record_shortcut", name: .init("xcodePreview"))
 		.environment(\.locale, .init(identifier: "ru"))
 }
 #endif

--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -136,11 +136,11 @@ extension KeyboardShortcuts.Recorder<Text> {
   - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
   */
   @_disfavoredOverload
-  public init<S>(
-    _ title: S,
+  public init(
+    _ title: String,
     name: KeyboardShortcuts.Name,
     onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
-  ) where S : StringProtocol {
+  ) {
     self.init(
       for: name,
       onChange: onChange,

--- a/Sources/KeyboardShortcuts/Recorder.swift
+++ b/Sources/KeyboardShortcuts/Recorder.swift
@@ -130,25 +130,25 @@ extension KeyboardShortcuts.Recorder<Text> {
 
 @available(macOS 10.15, *)
 extension KeyboardShortcuts.Recorder<Text> {
-  /**
-  - Parameter title: The title of the keyboard shortcut recorder, describing its purpose.
-  - Parameter name: Strongly-typed keyboard shortcut name.
-  - Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
-  */
-  @_disfavoredOverload
-  public init(
-    _ title: String,
-    name: KeyboardShortcuts.Name,
-    onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
-  ) {
-    self.init(
-      for: name,
-      onChange: onChange,
-      hasLabel: true
-    ) {
-      Text(title)
-    }
-  }
+	/**
+	- Parameter title: The title of the keyboard shortcut recorder, describing its purpose.
+	- Parameter name: Strongly-typed keyboard shortcut name.
+	- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+	*/
+	@_disfavoredOverload
+	public init(
+		_ title: String,
+		name: KeyboardShortcuts.Name,
+		onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+	) {
+		self.init(
+			for: name,
+			onChange: onChange,
+			hasLabel: true
+		) {
+			Text(title)
+		}
+	}
 }
 
 @available(macOS 10.15, *)


### PR DESCRIPTION
Currently I am using a Text view manually to localize the title to my shortcut recorder, because the existing initializer only takes a String and isn't localized automatically.

This PR adds a second initializer to Recorder so the caller can continue to use String (as currently supported) or a LocalizedStringKey (as Text does) for localization.

**NOTE: This doesn't add any localization burden to this package. This only enabled localization to work properly in the application using this package.**

To get the compiler to prefer the LocalizedStringKey initializer instead of the String version, SwiftUI labels the String version of the Text view initializer with `@_disfavoredOverload`. I copied that attribute directly from SwiftUI.Text's initializer, and it is necessary for this change to work.
(As explained [here](https://www.fivestars.blog/articles/disfavoredOverload/).)

If using a private attribute isn't acceptable for this package then another option would be to rename the initializer parameter of the LocalizedStringKey version to include 'localizationKey' or something like that. That would require the user to know to use the right version of init, but at least it makes it available, which is better than the status quo.

<img width="568" alt="Screenshot 2024-01-12 at 4 42 33 PM" src="https://github.com/sindresorhus/KeyboardShortcuts/assets/12513211/c3ff3a93-5d51-4750-956d-a599c131e680">

I also added a title to the previews so the change could be visible in Xcode with just the package open, but the preview doesn't load for me. I tested in my own application and confirmed it works there.


(The SwiftUI.Text LocalizedStringKey initializer also has a compiler attribute, `@_semantics`, but it is just used for optimizations of some kind so I left it off in the PR. What do you think of including it too? This [blog post](https://reintech.io/blog/understanding-using-swifts-semantics) discusses how it is used.)

<img width="540" alt="Screenshot 2024-01-12 at 4 45 25 PM" src="https://github.com/sindresorhus/KeyboardShortcuts/assets/12513211/c982a29a-38fd-4071-889a-3f81e42de5ac">
