### PR TITLE
feat: add support of visionOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,7 @@ let package = Package(
 	name: "KeyboardShortcuts",
 	defaultLocalization: "en",
 	platforms: [
-		.macOS(.v10_15),
-        .visionOS(.v1)
+		.macOS(.v10_15), .visionOS(.v1)
 	],
 	products: [
 		.library(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
 	name: "KeyboardShortcuts",
 	defaultLocalization: "en",
 	platforms: [
-		.macOS(.v10_15)
+		.macOS(.v10_15),
+        .visionOS(.v1)
 	],
 	products: [
 		.library(


### PR DESCRIPTION
I got a project who needs this library on visionOS but this platform wasn't supported on the `Package.swift`. 

I added it, compiled on Vision Pro simulator all is OK.