### PR TITLE
Added support for changeable SwiftUI .keyboardShortcuts, based on the…

### DIFF
--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -229,7 +229,7 @@ extension KeyboardShortcuts {
 			// This doesn't always work for SwiftUI generated NSMenuItems (from .keyboardShortcut()) - so we also use existingNSMenuForUs, above
 			KeyboardShortcuts.userDefaultsDisable(name: shortcutName)
 
-			self.eventMonitor = LocalEventMonitor(events: [.keyDown, .leftMouseUp, .rightMouseUp]) { [weak self] event in
+			eventMonitor = LocalEventMonitor(events: [.keyDown, .leftMouseUp, .rightMouseUp]) { [weak self] event in
 				guard let self else {
 					return nil
 				}

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -215,7 +215,7 @@ extension KeyboardShortcuts {
 			KeyboardShortcuts.isPaused = true // The position here matters.
 			
 			if let existingShortcut = getShortcut(for: shortcutName) {
-				// Assuming we have a consisten NSMenuItem state, find the NSMenuItem instance that represents us right now
+				// Assuming we have a consistent NSMenuItem state, find the NSMenuItem instance that represents us right now
 				// This works only if SwiftUI has updated the NSMenuItem.  It seems (macOS 15) that even if the shortcut state is updated on KeyboardShortcutView, that the actual NSMenuItem isn't refreshed
 				// This means that if we change it multiple times in a row, this lookup returns nil.
 				// What seems to work is just hanging onto the last found reference...

--- a/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -199,8 +199,8 @@ extension KeyboardShortcuts {
 			preventBecomingKey()
 		}
 
-		private var existingNSMenuForUs: NSMenuItem? = nil
-		
+		private var existingNSMenuForUs: NSMenuItem?
+
 		/// :nodoc:
 		override public func becomeFirstResponder() -> Bool {
 			let shouldBecomeFirstResponder = super.becomeFirstResponder()
@@ -233,10 +233,10 @@ extension KeyboardShortcuts {
 				guard let self else {
 					return nil
 				}
-				
+
 				let clickPoint = self.convert(event.locationInWindow, from: nil)
 				let clickMargin = 3.0
-				
+
 				if
 					event.type == .leftMouseUp || event.type == .rightMouseUp,
 					!self.bounds.insetBy(dx: -clickMargin, dy: -clickMargin).contains(clickPoint)
@@ -244,21 +244,21 @@ extension KeyboardShortcuts {
 					self.blur()
 					return event
 				}
-				
+
 				guard event.isKeyEvent else {
 					return nil
 				}
-				
+
 				if
 					event.modifiers.isEmpty,
 					event.specialKey == .tab
 				{
 					self.blur()
-					
+
 					// We intentionally bubble up the event so it can focus the next responder.
 					return event
 				}
-				
+
 				if
 					event.modifiers.isEmpty,
 					event.keyCode == kVK_Escape // TODO: Make this strongly typed.
@@ -266,7 +266,7 @@ extension KeyboardShortcuts {
 					self.blur()
 					return nil
 				}
-				
+
 				if
 					event.modifiers.isEmpty,
 					event.specialKey == .delete
@@ -276,7 +276,7 @@ extension KeyboardShortcuts {
 					self.clear()
 					return nil
 				}
-				
+
 				// The “shift” key is not allowed without other modifiers or a function key, since it doesn't actually work.
 				guard
 					!event.modifiers.subtracting(.shift).isEmpty
@@ -286,8 +286,8 @@ extension KeyboardShortcuts {
 					NSSound.beep()
 					return nil
 				}
-				
-				
+
+
 				if let menuItem = shortcut.takenByMainMenu {
 					let isOurOwnMenuInstance = existingNSMenuForUs != nil ? existingNSMenuForUs === menuItem : false
 					if !isOurOwnMenuInstance {
@@ -304,10 +304,10 @@ extension KeyboardShortcuts {
 						return nil
 					}
 				}
-				
+
 				if shortcut.isTakenBySystem {
 					self.blur()
-					
+
 					let modalResponse = NSAlert.showModal(
 						for: self.window,
 						title: "keyboard_shortcut_used_by_system".localized,
@@ -318,21 +318,20 @@ extension KeyboardShortcuts {
 							"force_use_shortcut".localized
 						]
 					)
-					
+
 					self.focus()
-					
+
 					// If the user has selected "Use Anyway" in the dialog (the second option), we'll continue setting the keyboard shorcut even though it's reserved by the system.
 					guard modalResponse == .alertSecondButtonReturn else {
 						return nil
 					}
 				}
-				
+
 				self.stringValue = "\(shortcut)"
 				self.showsCancelButton = true
-				
+
 				self.saveShortcut(shortcut)
 				self.blur()
-				
 				return nil
 			}.start()
 

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -242,12 +242,6 @@ private let keyToKeyEquivalentString: [KeyboardShortcuts.Key: String] = [
 	.f20: stringFromKeyCode(NSF20FunctionKey)
 ]
 
-extension KeyboardShortcuts.Key {
-	public var keyToCharacter: String? {
-		keyToCharacterMapping[self]
-	}
-}
-
 extension KeyboardShortcuts.Shortcut {
 	@MainActor // `TISGetInputSourceProperty` crashes if called on a non-main thread.
 	/**

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -153,6 +153,12 @@ extension KeyboardShortcuts.Shortcut {
 	}
 }
 
+extension KeyboardShortcuts.Key {
+	public var specialCharacterMapping: String? {
+		keyToCharacterMapping[self]
+	}
+}
+
 private let keyToCharacterMapping: [KeyboardShortcuts.Key: String] = [
 	.return: "↩",
 	.delete: "⌫",

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -153,12 +153,6 @@ extension KeyboardShortcuts.Shortcut {
 	}
 }
 
-extension KeyboardShortcuts.Key {
-	public var specialCharacterMapping: String? {
-		keyToCharacterMapping[self]
-	}
-}
-
 private let keyToCharacterMapping: [KeyboardShortcuts.Key: String] = [
 	.return: "↩",
 	.delete: "⌫",
@@ -248,9 +242,18 @@ private let keyToKeyEquivalentString: [KeyboardShortcuts.Key: String] = [
 	.f20: stringFromKeyCode(NSF20FunctionKey)
 ]
 
+extension KeyboardShortcuts.Key {
+	public var keyToCharacter: String? {
+		keyToCharacterMapping[self]
+	}
+}
+
 extension KeyboardShortcuts.Shortcut {
 	@MainActor // `TISGetInputSourceProperty` crashes if called on a non-main thread.
-	fileprivate func keyToCharacter() -> String? {
+	/**
+	 This returns a String represntation of the Key.
+	 */
+	public func keyToCharacter() -> String? {
 		// Some characters cannot be automatically translated.
 		if
 			let key,

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -1,0 +1,123 @@
+// Created by Neil Clayton on 17/07/2024.
+// Using ideas by mbenoukaiss, https://github.com/sindresorhus/KeyboardShortcuts/issues/101
+
+
+import Foundation
+import SwiftUI
+import KeyboardShortcuts
+import Carbon
+
+// Provides a SwiftUI like wrapper func, that feels the same as the normal SwiftUI keyboardShortcut
+@available(macOS 11.0, *)
+extension View {
+	@ViewBuilder
+	public func keyboardShortcut(_ shortcutName: KeyboardShortcuts.Name) -> some View {
+		KeyboardShortcutView(shortcutName: shortcutName) {
+			self
+		}
+	}
+}
+
+// Holds the state of the shortcut, and changes that state when the shortcut changes
+// This causes the related NSMenuItem to also update (yipeee)
+@available(macOS 11.0, *)
+struct KeyboardShortcutView<Content: View>: View {
+	@State private var shortcutName: KeyboardShortcuts.Name
+	@State private var shortcut: KeyboardShortcuts.Shortcut?
+
+	private var content: () -> Content
+
+	init(shortcutName: KeyboardShortcuts.Name, content: @escaping () -> Content) {
+		self.shortcutName = shortcutName
+		self.shortcut = KeyboardShortcuts.getShortcut(for: shortcutName)
+		self.content = content
+	}
+
+	@ViewBuilder
+	var shortcutBody: some View {
+		if let shortcut, let keyEquivalent = shortcut.toKeyEquivalent() {
+			content()
+					.keyboardShortcut(keyEquivalent, modifiers: shortcut.toEventModifiers())
+		} else {
+			content()
+		}
+	}
+
+	var body: some View {
+		shortcutBody
+				// Called only when the shortcut is updated
+				.onReceive(NotificationCenter.default.publisher(for: .shortcutByNameDidChange)) { notification in
+					if let name = notification.userInfo?["name"] as? KeyboardShortcuts.Name, name == shortcutName {
+						let current = KeyboardShortcuts.getShortcut(for: name)
+						// this updates the shortcut state locally, refreshing the View, thus updating the SwiftUI menu item
+						// It's also fine if it is nil (which happens when you set the shortcut, in RecorderCocoa).
+						// See the comment on becomeFirstResponder (in short: so that you can reassign the SAME keypress to a shortcut, without it whining that it's already in use)
+						print("Shortcut \(shortcutName) updated to: \(current?.description ?? "nil")")
+						shortcut = current
+					}
+				}
+	}
+}
+
+@available(macOS 11.0, *)
+extension KeyboardShortcuts.Shortcut {
+	func toKeyEquivalent() -> KeyEquivalent? {
+		let carbonKeyCode = UInt16(self.carbonKeyCode)
+		let maxNameLength = 4
+		var nameBuffer = [UniChar](repeating: 0, count: maxNameLength)
+		var nameLength = 0
+
+		let modifierKeys = UInt32(alphaLock >> 8) & 0xFF // Caps Lock
+		var deadKeys: UInt32 = 0
+		let keyboardType = UInt32(LMGetKbdType())
+
+		let source = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
+		guard let ptr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+			NSLog("Could not get keyboard layout data")
+			return nil
+		}
+		let layoutData = Unmanaged<CFData>.fromOpaque(ptr).takeUnretainedValue() as Data
+		let osStatus = layoutData.withUnsafeBytes {
+			UCKeyTranslate($0.bindMemory(to: UCKeyboardLayout.self).baseAddress, carbonKeyCode, UInt16(kUCKeyActionDown),
+					modifierKeys, keyboardType, UInt32(kUCKeyTranslateNoDeadKeysMask),
+					&deadKeys, maxNameLength, &nameLength, &nameBuffer)
+		}
+		guard osStatus == noErr else {
+			NSLog("Code: 0x%04X  Status: %+i", carbonKeyCode, osStatus);
+			return nil
+		}
+
+		return KeyEquivalent(Character(String(utf16CodeUnits: nameBuffer, count: nameLength)))
+	}
+
+	func toEventModifiers() -> SwiftUI.EventModifiers {
+		var modifiers: SwiftUI.EventModifiers = []
+
+		if self.modifiers.contains(NSEvent.ModifierFlags.command) {
+			modifiers.update(with: EventModifiers.command)
+		}
+
+		if self.modifiers.contains(NSEvent.ModifierFlags.control) {
+			modifiers.update(with: EventModifiers.control)
+		}
+
+		if self.modifiers.contains(NSEvent.ModifierFlags.option) {
+			modifiers.update(with: EventModifiers.option)
+		}
+
+		if self.modifiers.contains(NSEvent.ModifierFlags.shift) {
+			modifiers.update(with: EventModifiers.shift)
+		}
+
+		if self.modifiers.contains(NSEvent.ModifierFlags.capsLock) {
+			modifiers.update(with: EventModifiers.capsLock)
+		}
+
+		if self.modifiers.contains(NSEvent.ModifierFlags.numericPad) {
+			modifiers.update(with: EventModifiers.numericPad)
+		}
+
+		return modifiers
+	}
+
+}

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -30,6 +30,7 @@ extension KeyboardShortcuts.Shortcut {
 // Holds the state of the shortcut, and changes that state when the shortcut changes
 // This causes the related NSMenuItem to also update (yipeee)
 @available(macOS 12.3, *)
+@MainActor
 struct KeyboardShortcutView<Content: View>: View {
 	@State private var shortcutName: KeyboardShortcuts.Name
 	@State private var shortcut: KeyboardShortcuts.Shortcut?

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -74,33 +74,6 @@ extension KeyboardShortcuts.Shortcut {
 			return nil
 		}
 		return KeyEquivalent(Character(keyCharacter))
-		
-//		let carbonKeyCode = UInt16(self.carbonKeyCode)
-//		let maxNameLength = 4
-//		var nameBuffer = [UniChar](repeating: 0, count: maxNameLength)
-//		var nameLength = 0
-//
-//		let modifierKeys = UInt32(alphaLock >> 8) & 0xFF // Caps Lock
-//		var deadKeys: UInt32 = 0
-//		let keyboardType = UInt32(LMGetKbdType())
-//
-//		let source = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
-//		guard let ptr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
-//			NSLog("Could not get keyboard layout data")
-//			return nil
-//		}
-//		let layoutData = Unmanaged<CFData>.fromOpaque(ptr).takeUnretainedValue() as Data
-//		let osStatus = layoutData.withUnsafeBytes {
-//			UCKeyTranslate($0.bindMemory(to: UCKeyboardLayout.self).baseAddress, carbonKeyCode, UInt16(kUCKeyActionDown),
-//					modifierKeys, keyboardType, UInt32(kUCKeyTranslateNoDeadKeysMask),
-//					&deadKeys, maxNameLength, &nameLength, &nameBuffer)
-//		}
-//		guard osStatus == noErr else {
-//			NSLog("Code: 0x%04X  Status: %+i", carbonKeyCode, osStatus);
-//			return nil
-//		}
-//
-//		return KeyEquivalent(Character(String(utf16CodeUnits: nameBuffer, count: nameLength)))
 	}
 
 	var toEventModifiers: SwiftUI.EventModifiers {

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -6,10 +6,9 @@ import Foundation
 import SwiftUI
 import Carbon
 
-// Provides a SwiftUI like wrapper func, that feels the same as the normal SwiftUI keyboardShortcut
+// Provides a SwiftUI like wrapper function, that feels the same as the normal SwiftUI .keyboardShortcut view extension
 @available(macOS 12.3, *)
 extension View {
-	@ViewBuilder
 	public func keyboardShortcut(_ shortcutName: KeyboardShortcuts.Name) -> some View {
 		KeyboardShortcutView(shortcutName: shortcutName) {
 			self
@@ -60,7 +59,6 @@ struct KeyboardShortcutView<Content: View>: View {
 					// this updates the shortcut state locally, refreshing the View, thus updating the SwiftUI menu item
 					// It's also fine if it is nil (which happens when you set the shortcut, in RecorderCocoa).
 					// See the comment on becomeFirstResponder (in short: so that you can reassign the SAME keypress to a shortcut, without it whining that it's already in use)
-//					print("Shortcut \(shortcutName) updated to: \(current?.description ?? "nil")")
 					shortcut = current
 				}
 	}

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -4,11 +4,10 @@
 
 import Foundation
 import SwiftUI
-import KeyboardShortcuts
 import Carbon
 
 // Provides a SwiftUI like wrapper func, that feels the same as the normal SwiftUI keyboardShortcut
-@available(macOS 11.0, *)
+@available(macOS 12.3, *)
 extension View {
 	@ViewBuilder
 	public func keyboardShortcut(_ shortcutName: KeyboardShortcuts.Name) -> some View {
@@ -18,9 +17,20 @@ extension View {
 	}
 }
 
+@available(macOS 11.0, *)
+extension KeyboardShortcuts.Shortcut {
+	@MainActor
+	var swiftKeyboardShortcut: KeyboardShortcut? {
+		if let keyEquivalent = toKeyEquivalent() {
+			return KeyboardShortcut(keyEquivalent, modifiers: toEventModifiers)
+		}
+		return nil
+	}
+}
+
 // Holds the state of the shortcut, and changes that state when the shortcut changes
 // This causes the related NSMenuItem to also update (yipeee)
-@available(macOS 11.0, *)
+@available(macOS 12.3, *)
 struct KeyboardShortcutView<Content: View>: View {
 	@State private var shortcutName: KeyboardShortcuts.Name
 	@State private var shortcut: KeyboardShortcuts.Shortcut?
@@ -35,86 +45,89 @@ struct KeyboardShortcutView<Content: View>: View {
 
 	@ViewBuilder
 	var shortcutBody: some View {
-		if let shortcut, let keyEquivalent = shortcut.toKeyEquivalent() {
-			content()
-					.keyboardShortcut(keyEquivalent, modifiers: shortcut.toEventModifiers())
-		} else {
-			content()
-		}
+		content()
+			.keyboardShortcut(shortcut?.swiftKeyboardShortcut)
 	}
 
 	var body: some View {
 		shortcutBody
 				// Called only when the shortcut is updated
 				.onReceive(NotificationCenter.default.publisher(for: .shortcutByNameDidChange)) { notification in
-					if let name = notification.userInfo?["name"] as? KeyboardShortcuts.Name, name == shortcutName {
-						let current = KeyboardShortcuts.getShortcut(for: name)
-						// this updates the shortcut state locally, refreshing the View, thus updating the SwiftUI menu item
-						// It's also fine if it is nil (which happens when you set the shortcut, in RecorderCocoa).
-						// See the comment on becomeFirstResponder (in short: so that you can reassign the SAME keypress to a shortcut, without it whining that it's already in use)
-						print("Shortcut \(shortcutName) updated to: \(current?.description ?? "nil")")
-						shortcut = current
+					guard let name = notification.userInfo?["name"] as? KeyboardShortcuts.Name, name == shortcutName else {
+						return
 					}
+					let current = KeyboardShortcuts.getShortcut(for: name)
+					// this updates the shortcut state locally, refreshing the View, thus updating the SwiftUI menu item
+					// It's also fine if it is nil (which happens when you set the shortcut, in RecorderCocoa).
+					// See the comment on becomeFirstResponder (in short: so that you can reassign the SAME keypress to a shortcut, without it whining that it's already in use)
+//					print("Shortcut \(shortcutName) updated to: \(current?.description ?? "nil")")
+					shortcut = current
 				}
 	}
 }
 
 @available(macOS 11.0, *)
 extension KeyboardShortcuts.Shortcut {
+	@MainActor
 	func toKeyEquivalent() -> KeyEquivalent? {
-		let carbonKeyCode = UInt16(self.carbonKeyCode)
-		let maxNameLength = 4
-		var nameBuffer = [UniChar](repeating: 0, count: maxNameLength)
-		var nameLength = 0
-
-		let modifierKeys = UInt32(alphaLock >> 8) & 0xFF // Caps Lock
-		var deadKeys: UInt32 = 0
-		let keyboardType = UInt32(LMGetKbdType())
-
-		let source = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
-		guard let ptr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
-			NSLog("Could not get keyboard layout data")
+		guard let keyCharacter = keyToCharacter() else {
 			return nil
 		}
-		let layoutData = Unmanaged<CFData>.fromOpaque(ptr).takeUnretainedValue() as Data
-		let osStatus = layoutData.withUnsafeBytes {
-			UCKeyTranslate($0.bindMemory(to: UCKeyboardLayout.self).baseAddress, carbonKeyCode, UInt16(kUCKeyActionDown),
-					modifierKeys, keyboardType, UInt32(kUCKeyTranslateNoDeadKeysMask),
-					&deadKeys, maxNameLength, &nameLength, &nameBuffer)
-		}
-		guard osStatus == noErr else {
-			NSLog("Code: 0x%04X  Status: %+i", carbonKeyCode, osStatus);
-			return nil
-		}
-
-		return KeyEquivalent(Character(String(utf16CodeUnits: nameBuffer, count: nameLength)))
+		return KeyEquivalent(Character(keyCharacter))
+		
+//		let carbonKeyCode = UInt16(self.carbonKeyCode)
+//		let maxNameLength = 4
+//		var nameBuffer = [UniChar](repeating: 0, count: maxNameLength)
+//		var nameLength = 0
+//
+//		let modifierKeys = UInt32(alphaLock >> 8) & 0xFF // Caps Lock
+//		var deadKeys: UInt32 = 0
+//		let keyboardType = UInt32(LMGetKbdType())
+//
+//		let source = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
+//		guard let ptr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+//			NSLog("Could not get keyboard layout data")
+//			return nil
+//		}
+//		let layoutData = Unmanaged<CFData>.fromOpaque(ptr).takeUnretainedValue() as Data
+//		let osStatus = layoutData.withUnsafeBytes {
+//			UCKeyTranslate($0.bindMemory(to: UCKeyboardLayout.self).baseAddress, carbonKeyCode, UInt16(kUCKeyActionDown),
+//					modifierKeys, keyboardType, UInt32(kUCKeyTranslateNoDeadKeysMask),
+//					&deadKeys, maxNameLength, &nameLength, &nameBuffer)
+//		}
+//		guard osStatus == noErr else {
+//			NSLog("Code: 0x%04X  Status: %+i", carbonKeyCode, osStatus);
+//			return nil
+//		}
+//
+//		return KeyEquivalent(Character(String(utf16CodeUnits: nameBuffer, count: nameLength)))
 	}
 
-	func toEventModifiers() -> SwiftUI.EventModifiers {
+	var toEventModifiers: SwiftUI.EventModifiers {
 		var modifiers: SwiftUI.EventModifiers = []
 
 		if self.modifiers.contains(NSEvent.ModifierFlags.command) {
-			modifiers.update(with: EventModifiers.command)
+			modifiers.insert(EventModifiers.command)
 		}
 
 		if self.modifiers.contains(NSEvent.ModifierFlags.control) {
-			modifiers.update(with: EventModifiers.control)
+			modifiers.insert(EventModifiers.control)
 		}
 
 		if self.modifiers.contains(NSEvent.ModifierFlags.option) {
-			modifiers.update(with: EventModifiers.option)
+			modifiers.insert(EventModifiers.option)
 		}
 
 		if self.modifiers.contains(NSEvent.ModifierFlags.shift) {
-			modifiers.update(with: EventModifiers.shift)
+			modifiers.insert(EventModifiers.shift)
 		}
 
 		if self.modifiers.contains(NSEvent.ModifierFlags.capsLock) {
-			modifiers.update(with: EventModifiers.capsLock)
+			modifiers.insert(EventModifiers.capsLock)
 		}
 
 		if self.modifiers.contains(NSEvent.ModifierFlags.numericPad) {
-			modifiers.update(with: EventModifiers.numericPad)
+			modifiers.insert(EventModifiers.numericPad)
 		}
 
 		return modifiers

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -42,7 +42,6 @@ struct KeyboardShortcutView<Content: View>: View {
 		self.content = content
 	}
 
-	@ViewBuilder
 	var shortcutBody: some View {
 		content()
 			.keyboardShortcut(shortcut?.swiftKeyboardShortcut)

--- a/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
+++ b/Sources/KeyboardShortcuts/SwiftUI+Extensions.swift
@@ -9,6 +9,7 @@ import Carbon
 // Provides a SwiftUI like wrapper function, that feels the same as the normal SwiftUI .keyboardShortcut view extension
 @available(macOS 12.3, *)
 extension View {
+	@MainActor
 	public func keyboardShortcut(_ shortcutName: KeyboardShortcuts.Name) -> some View {
 		KeyboardShortcutView(shortcutName: shortcutName) {
 			self


### PR DESCRIPTION
This adds support for SwiftUI menu items (they now auto update when shortcuts are changed).

Also; it won't throw up a UI when modifying the existing shortcut.  The implementation ... isn't great (it relies on comparing the instance points of NSMenuItems), but I can't find any other alternative where I can correctly identify that a SwiftUI generated NSMenuItem is related to a given shortcut.

- Added support for changeable SwiftUI .keyboardShortcuts, based on the work done by @mbenoukaiss
- Modified RecorderCocoa so that it doesn't show a dialog if we are reassigning one of our own menu items