### PR TITLE
Improve localizations and Fix recorder not allowing multiple modifiers when option is present

### DIFF
--- a/Sources/KeyboardShortcuts/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/KeyboardShortcuts/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,9 +1,9 @@
 "record_shortcut" = "设置快捷键";
 "press_shortcut" = "按下快捷键";
-"keyboard_shortcut_used_by_menu_item" = "当前快捷键无法使用，因为它已被用作菜单项 “%@” 的快捷键。";
+"keyboard_shortcut_used_by_menu_item" = "当前快捷键无法使用，因为它已被用作菜单项“%@”的快捷键。";
 "keyboard_shortcut_used_by_system" = "当前快捷键无法使用，因为它已被用作系统快捷键。";
-"keyboard_shortcuts_can_be_changed" = "可以在 “系统设置 › 键盘 › 键盘快捷键” 中更改大多数系统快捷键。";
-"keyboard_shortcut_disallowed" = "Option 修飾鍵必須與 Command 或 Control 組合使用。";
+"keyboard_shortcuts_can_be_changed" = "可以在“系统设置 › 键盘 › 键盘快捷键”中更改大多数系统快捷键。";
+"keyboard_shortcut_disallowed" = "Option键必须与Command键或Control键组合使用。";
 "force_use_shortcut" = "强制使用";
 "ok" = "好";
 "space_key" = "空格";

--- a/Sources/KeyboardShortcuts/Localization/zh-TW.lproj/Localizable.strings
+++ b/Sources/KeyboardShortcuts/Localization/zh-TW.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 "keyboard_shortcut_used_by_menu_item" = "此快速鍵無法使用，因為它已被選單項目「%@」使用。";
 "keyboard_shortcut_used_by_system" = "此快速鍵無法使用，因為它已被系統使用。";
 "keyboard_shortcuts_can_be_changed" = "可以在「系統設定 › 鍵盤 › 鍵盤快速鍵」中更改大多數的系統快速鍵。";
-"keyboard_shortcut_disallowed" = "Option 鍵必須與 Command 或 Control 鍵組合使用。";
+"keyboard_shortcut_disallowed" = "Option鍵必須與Command鍵或Control鍵組合使用。";
 "force_use_shortcut" = "強制使用";
 "ok" = "好";
 "space_key" = "空格";

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -117,7 +117,7 @@ extension KeyboardShortcuts.Shortcut {
 
 		// If Option is present, ensure there's at least one modifier other than Option and Shift
 		let otherModifiers: NSEvent.ModifierFlags = [.command, .control, .function, .capsLock]
-		return !modifiers.isDisjoint(with: otherModifiers)
+		return modifiers.isDisjoint(with: otherModifiers)
 	}
 
 	/**


### PR DESCRIPTION
- Change Traditional Chinese to Simplified Chinese in zh-Hans.
- Remove unneeded space between English words and Chinese characters.
- Fix shortcut recorder not allowing other modifiers when option is present on macOS 15.
