### PR TITLE
Fix initial `isPressed` registration in `KeyboardShortcutsExample`

### DIFF
--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -66,7 +66,7 @@ private struct DynamicShortcut: View {
 		.frame(maxWidth: 300)
 		.padding()
 		.padding(.bottom, 20)
-		.onChange(of: shortcut) { oldValue, newValue in
+		.onChange(of: shortcut, initial: true) { oldValue, newValue in
 			onShortcutChange(oldValue: oldValue, newValue: newValue)
 		}
 	}


### PR DESCRIPTION
The `isPressed` indicator was not changing for shortcuts created with the `DynamicShortcutRecorder`. This was cause by registration being done with `.onChange(of:_:)` - where `action` is only evaluated with the first change of the value. Specify `initial` so that it is evaluated on appearance as well.