### PR TITLE
Add methods for removing handlers for specific `Name`s

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -7,8 +7,8 @@ Global keyboard shortcuts for your macOS app.
 public enum KeyboardShortcuts {
 	private static var registeredShortcuts = Set<Shortcut>()
 
-	private static var legacyKeyDownHandlers = [Name: [() -> Void]]()
-	private static var legacyKeyUpHandlers = [Name: [() -> Void]]()
+	internal static var legacyKeyDownHandlers = [Name: [() -> Void]]()
+	internal static var legacyKeyUpHandlers = [Name: [() -> Void]]()
 
 	private static var streamKeyDownHandlers = [Name: [UUID: () -> Void]]()
 	private static var streamKeyUpHandlers = [Name: [UUID: () -> Void]]()
@@ -179,6 +179,34 @@ public enum KeyboardShortcuts {
 
 		legacyKeyDownHandlers = [:]
 		legacyKeyUpHandlers = [:]
+	}
+
+	/**
+	 Remove all handlers for one or more names. Includes both "key down" and "key up" handlers.
+	 */
+	public static func removeHandlers(for names: [Name]) {
+		for name in names {
+			legacyKeyDownHandlers[name, default: []].removeAll()
+			legacyKeyUpHandlers[name, default: []].removeAll()
+		}
+	}
+
+	/**
+	 Remove all "key down" handlers for one or more names.
+	 */
+	public static func removeKeyDownHandlers(for names: [Name]) {
+		for name in names {
+			legacyKeyDownHandlers[name, default: []].removeAll()
+		}
+	}
+
+	/**
+	 Remove all "key up" handlers for one or more names.
+	 */
+	public static func removeKeyUpHandlers(for names: [Name]) {
+		for name in names {
+			legacyKeyUpHandlers[name, default: []].removeAll()
+		}
 	}
 
 	// TODO: Also add `.isEnabled(_ name: Name)`.

--- a/Tests/KeyboardShortcutsTests/KeyboardShortcutsTests.swift
+++ b/Tests/KeyboardShortcutsTests/KeyboardShortcutsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import KeyboardShortcuts
+@testable import KeyboardShortcuts
 
 final class KeyboardShortcutsTests: XCTestCase {
 	// TODO: Add more tests.
@@ -26,5 +26,134 @@ final class KeyboardShortcutsTests: XCTestCase {
 
 		XCTAssertNil(KeyboardShortcuts.getShortcut(for: shortcutName1))
 		XCTAssertEqual(KeyboardShortcuts.getShortcut(for: shortcutName2), defaultShortcut)
+	}
+
+	func testRemoveHandlersForNames() throws {
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a)
+		let shortcut2 = KeyboardShortcuts.Shortcut(.b)
+
+		let shortcutName1 = KeyboardShortcuts.Name("testRemoveHandlersForNames1")
+		let shortcutName2 = KeyboardShortcuts.Name("testRemoveHandlersForNames2")
+
+		KeyboardShortcuts.setShortcut(shortcut1, for: shortcutName1)
+		KeyboardShortcuts.setShortcut(shortcut2, for: shortcutName2)
+
+		KeyboardShortcuts.onKeyDown(for: shortcutName1) {
+			print("Shortcut 1 is down")
+		}
+		KeyboardShortcuts.onKeyUp(for: shortcutName1) {
+			print("Shortcut 1 is up")
+		}
+		KeyboardShortcuts.onKeyDown(for: shortcutName2) {
+			print("Shortcut 2 is down")
+		}
+		KeyboardShortcuts.onKeyUp(for: shortcutName2) {
+			print("Shortcut 2 is up")
+		}
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+
+		KeyboardShortcuts.removeHandlers(for: [shortcutName1])
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+
+		KeyboardShortcuts.removeHandlers(for: [shortcutName2])
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 0)
+	}
+
+	func testRemoveKeyDownHandlersForNames() throws {
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a)
+		let shortcut2 = KeyboardShortcuts.Shortcut(.b)
+
+		let shortcutName1 = KeyboardShortcuts.Name("testRemoveKeyDownHandlersForNames1")
+		let shortcutName2 = KeyboardShortcuts.Name("testRemoveKeyDownHandlersForNames2")
+
+		KeyboardShortcuts.setShortcut(shortcut1, for: shortcutName1)
+		KeyboardShortcuts.setShortcut(shortcut2, for: shortcutName2)
+
+		KeyboardShortcuts.onKeyDown(for: shortcutName1) {
+			print("Shortcut 1 is down")
+		}
+		KeyboardShortcuts.onKeyUp(for: shortcutName1) {
+			print("Shortcut 1 is up")
+		}
+		KeyboardShortcuts.onKeyDown(for: shortcutName2) {
+			print("Shortcut 2 is down")
+		}
+		KeyboardShortcuts.onKeyUp(for: shortcutName2) {
+			print("Shortcut 2 is up")
+		}
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+
+		KeyboardShortcuts.removeKeyDownHandlers(for: [shortcutName1])
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+
+		KeyboardShortcuts.removeKeyDownHandlers(for: [shortcutName2])
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+	}
+
+	func testRemoveKeyUpHandlersForNames() throws {
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a)
+		let shortcut2 = KeyboardShortcuts.Shortcut(.b)
+
+		let shortcutName1 = KeyboardShortcuts.Name("testRemoveKeyUpHandlersForNames1")
+		let shortcutName2 = KeyboardShortcuts.Name("testRemoveKeyUpHandlersForNames2")
+
+		KeyboardShortcuts.setShortcut(shortcut1, for: shortcutName1)
+		KeyboardShortcuts.setShortcut(shortcut2, for: shortcutName2)
+
+		KeyboardShortcuts.onKeyDown(for: shortcutName1) {
+			print("Shortcut 1 is down")
+		}
+		KeyboardShortcuts.onKeyUp(for: shortcutName1) {
+			print("Shortcut 1 is up")
+		}
+		KeyboardShortcuts.onKeyDown(for: shortcutName2) {
+			print("Shortcut 2 is down")
+		}
+		KeyboardShortcuts.onKeyUp(for: shortcutName2) {
+			print("Shortcut 2 is up")
+		}
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+
+		KeyboardShortcuts.removeKeyUpHandlers(for: [shortcutName1])
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 1)
+
+		KeyboardShortcuts.removeKeyUpHandlers(for: [shortcutName2])
+
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName1]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyDownHandlers[shortcutName2]?.count, 1)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName1]?.count, 0)
+		XCTAssertEqual(KeyboardShortcuts.legacyKeyUpHandlers[shortcutName2]?.count, 0)
 	}
 }


### PR DESCRIPTION
Adds the following methods for removing only the handlers for specific `Name`s:

```swift
/**
Remove all handlers for one or more names. Includes both "key down" and "key up" handlers.
*/
public static func removeHandlers(for names: [Name]) {}

/**
Remove all "key down" handlers for one or more names.
*/
public static func removeKeyDownHandlers(for names: [Name]) {}

/**
Remove all "key up" handlers for one or more names.
*/
public static func removeKeyUpHandlers(for names: [Name]) {}
```

> NOTE: I also made `legacyKeyDownHandlers` and `legacyKeyUpHandlers` internal for testing purposes.

