### PR TITLE
Restore Option key shortcuts for macOS 15.2 and later

### DIFF
--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -105,8 +105,11 @@ extension KeyboardShortcuts.Shortcut {
 	Check whether the keyboard shortcut is disallowed.
 	*/
 	var isDisallowed: Bool {
+		let osVersion = ProcessInfo().operatingSystemVersion
+		
 		guard
-			#available(macOS 15, *),
+			osVersion.majorVersion == 15,
+			(osVersion.minorVersion == 0 || osVersion.minorVersion == 1),
 			Constants.isSandboxed
 		else {
 			return false

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -105,11 +105,11 @@ extension KeyboardShortcuts.Shortcut {
 	Check whether the keyboard shortcut is disallowed.
 	*/
 	var isDisallowed: Bool {
-		let osVersion = ProcessInfo().operatingSystemVersion
-		
+		let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+
 		guard
 			osVersion.majorVersion == 15,
-			(osVersion.minorVersion == 0 || osVersion.minorVersion == 1),
+			osVersion.minorVersion == 0 || osVersion.minorVersion == 1,
 			Constants.isSandboxed
 		else {
 			return false


### PR DESCRIPTION
This PR allows option key shortcuts for macOS 15.2 and later.