### PR TITLE
Made sure multi-platform project compiles

### DIFF
--- a/Sources/KeyboardShortcuts/Utilities.swift
+++ b/Sources/KeyboardShortcuts/Utilities.swift
@@ -510,6 +510,7 @@ extension Dictionary {
 }
 #endif
 
+
 @available(iOS 14.0, *)
 @available(macOS 11.0, *)
 extension KeyEquivalent {

--- a/Sources/KeyboardShortcuts/Utilities.swift
+++ b/Sources/KeyboardShortcuts/Utilities.swift
@@ -507,6 +507,17 @@ extension Dictionary {
 		index(forKey: key) != nil
 	}
 }
+
+@available(macOS 11.0, *)
+extension KeyEquivalent {
+	init?(unicodeScalarValue value: Int) {
+		guard let character = Character(unicodeScalarValue: value) else {
+			return nil
+		}
+
+		self = KeyEquivalent(character)
+	}
+}
 #endif
 
 
@@ -533,17 +544,6 @@ extension StringProtocol {
 		}
 
 		return replacement + dropFirst(prefix.count)
-	}
-}
-
-@available(macOS 11.0, *)
-extension KeyEquivalent {
-	init?(unicodeScalarValue value: Int) {
-		guard let character = Character(unicodeScalarValue: value) else {
-			return nil
-		}
-
-		self = KeyEquivalent(character)
 	}
 }
 

--- a/Sources/KeyboardShortcuts/Utilities.swift
+++ b/Sources/KeyboardShortcuts/Utilities.swift
@@ -1,6 +1,7 @@
+import SwiftUI
+
 #if os(macOS)
 import Carbon.HIToolbox
-import SwiftUI
 
 
 extension String {
@@ -507,7 +508,9 @@ extension Dictionary {
 		index(forKey: key) != nil
 	}
 }
+#endif
 
+@available(iOS 14.0, *)
 @available(macOS 11.0, *)
 extension KeyEquivalent {
 	init?(unicodeScalarValue value: Int) {
@@ -518,7 +521,6 @@ extension KeyEquivalent {
 		self = KeyEquivalent(character)
 	}
 }
-#endif
 
 
 extension Sequence where Element: Hashable {


### PR DESCRIPTION
Removed the `KeyEquivalent` extension from iOS builds so they compile.