### PR TITLE
Custom UserDefaults for 

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -37,6 +37,24 @@ public enum KeyboardShortcuts {
 
 	private static var openMenuObserver: NSObjectProtocol?
 	private static var closeMenuObserver: NSObjectProtocol?
+	
+	public static var customDefaults: UserDefaults? {
+		get {
+			_customDefaults
+		}
+
+		set {
+			_customDefaults = newValue
+		}
+	}
+
+	static var _customDefaults: UserDefaults? {
+		didSet {
+			userDefaults = _customDefaults ?? .standard
+		}
+	}
+
+	static var userDefaults: UserDefaults = .standard
 
 	/**
 	When `true`, event handlers will not be called for registered keyboard shortcuts.
@@ -59,7 +77,7 @@ public enum KeyboardShortcuts {
 	}
 
 	static var allNames: Set<Name> {
-		UserDefaults.standard.dictionaryRepresentation()
+		KeyboardShortcuts.userDefaults.dictionaryRepresentation()
 			.compactMap { key, _ in
 				guard key.hasPrefix(userDefaultsPrefix) else {
 					return nil
@@ -326,7 +344,7 @@ public enum KeyboardShortcuts {
 	*/
 	public static func getShortcut(for name: Name) -> Shortcut? {
 		guard
-			let data = UserDefaults.standard.string(forKey: userDefaultsKey(for: name))?.data(using: .utf8),
+			let data = KeyboardShortcuts.userDefaults.string(forKey: userDefaultsKey(for: name))?.data(using: .utf8),
 			let decoded = try? JSONDecoder().decode(Shortcut.self, from: data)
 		else {
 			return nil
@@ -459,7 +477,7 @@ public enum KeyboardShortcuts {
 		}
 
 		register(shortcut)
-		UserDefaults.standard.set(encoded, forKey: userDefaultsKey(for: name))
+		KeyboardShortcuts.userDefaults.set(encoded, forKey: userDefaultsKey(for: name))
 		userDefaultsDidChange(name: name)
 	}
 
@@ -468,7 +486,7 @@ public enum KeyboardShortcuts {
 			return
 		}
 
-		UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
+		KeyboardShortcuts.userDefaults.set(false, forKey: userDefaultsKey(for: name))
 		unregister(shortcut)
 		userDefaultsDidChange(name: name)
 	}
@@ -478,13 +496,13 @@ public enum KeyboardShortcuts {
 			return
 		}
 
-		UserDefaults.standard.removeObject(forKey: userDefaultsKey(for: name))
+		KeyboardShortcuts.userDefaults.removeObject(forKey: userDefaultsKey(for: name))
 		unregister(shortcut)
 		userDefaultsDidChange(name: name)
 	}
 
 	static func userDefaultsContains(name: Name) -> Bool {
-		UserDefaults.standard.object(forKey: userDefaultsKey(for: name)) != nil
+		KeyboardShortcuts.userDefaults.object(forKey: userDefaultsKey(for: name)) != nil
 	}
 }
 


### PR DESCRIPTION
I am using KeyboardShortcuts in an environment with [App Groups](https://developer.apple.com/documentation/xcode/configuring-app-groups). The shared UserDefaults shall also include the defined shortcuts. 

This PR adds the capability to define a custom UserDefaults to support App Groups and access group containers.