### PR TITLE
Check the enablement status of a keyboard shortcut

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -200,7 +200,7 @@ public enum KeyboardShortcuts {
 		guard isEnabled else {
 			return false
 		}
-		
+
 		guard let shortcut = getShortcut(for: name) else {
 			return false
 		}

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -182,28 +182,6 @@ public enum KeyboardShortcuts {
 	}
 
 	/**
-	Returns whether the keyboard shortcut for the given name is enabled.
-
-	This checks if the shortcut is registered and will trigger handlers. It respects `KeyboardShortcuts.isEnabled`.
-
-	```swift
-	let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
-	```
-
-	- Tip: Use ``disable(_:)`` and ``enable(_:)`` to change the status.
-	*/
-	public static func isEnabled(for name: Name) -> Bool {
-		guard
-			isEnabled,
-			let shortcut = getShortcut(for: name)
-		else {
-			return false
-		}
-
-		return registeredShortcuts.contains(shortcut)
-	}
-
-	/**
 	Remove the keyboard shortcut handler for the given name.
 
 	This can be used to reset the handler before re-creating it to avoid having multiple handlers for the same shortcut.
@@ -225,6 +203,28 @@ public enum KeyboardShortcuts {
 		}
 
 		unregister(shortcut)
+	}
+
+	/**
+	Returns whether the keyboard shortcut for the given name is enabled.
+
+	This checks if the shortcut is registered and will trigger handlers. It respects `KeyboardShortcuts.isEnabled`.
+
+	```swift
+	let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
+	```
+
+	- Tip: Use ``disable(_:)`` and ``enable(_:)`` to change the status.
+	*/
+	public static func isEnabled(for name: Name) -> Bool {
+		guard
+			isEnabled,
+			let shortcut = getShortcut(for: name)
+		else {
+			return false
+		}
+
+		return registeredShortcuts.contains(shortcut)
 	}
 
 	/**

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -88,6 +88,29 @@ public enum KeyboardShortcuts {
 		}
 	}
 
+	/**
+	Check if a keyboard shortcut is enabled for the given name.
+
+	This method checks if the shortcut associated with the given name is currently registered and enabled. Use `enable` or `disable` methods
+
+	- Parameter name: The name of the keyboard shortcut to check.
+	- Returns: `true` if the shortcut is enabled and registered, `false` otherwise.
+
+	- Note: A keyboard shortcut's enablement status can be manually adjusted through the `enable(_:)` or `disable(_:)` methods.
+
+	```swift
+	// Check if the "toggleUnicornMode" shortcut is enabled
+	let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
+	```
+	*/
+	public static func isEnabled(for name: Name) -> Bool {
+		guard let shortcut = getShortcut(for: name) else {
+			return false
+		}
+
+		return registeredShortcuts.contains(shortcut)
+	}
+
 	private static func register(_ shortcut: Shortcut) {
 		guard !registeredShortcuts.contains(shortcut) else {
 			return

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -88,29 +88,6 @@ public enum KeyboardShortcuts {
 		}
 	}
 
-	/**
-	Check if a keyboard shortcut is enabled for the given name.
-
-	This method checks if the shortcut associated with the given name is currently registered and enabled. Use `enable` or `disable` methods
-
-	- Parameter name: The name of the keyboard shortcut to check.
-	- Returns: `true` if the shortcut is enabled and registered, `false` otherwise.
-
-	- Note: A keyboard shortcut's enablement status can be manually adjusted through the `enable(_:)` or `disable(_:)` methods.
-
-	```swift
-	// Check if the "toggleUnicornMode" shortcut is enabled
-	let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
-	```
-	*/
-	public static func isEnabled(for name: Name) -> Bool {
-		guard let shortcut = getShortcut(for: name) else {
-			return false
-		}
-
-		return registeredShortcuts.contains(shortcut)
-	}
-
 	private static func register(_ shortcut: Shortcut) {
 		guard !registeredShortcuts.contains(shortcut) else {
 			return
@@ -204,7 +181,28 @@ public enum KeyboardShortcuts {
 		legacyKeyUpHandlers = [:]
 	}
 
-	// TODO: Also add `.isEnabled(_ name: Name)`.
+	/**
+	 Check if a keyboard shortcut is enabled for the given name.
+
+	 This method checks if the shortcut associated with the given name is currently registered and enabled. Use `enable` or `disable` methods
+
+	 - Parameter name: The name of the keyboard shortcut to check.
+	 - Returns: `true` if the shortcut is enabled and registered, `false` otherwise.
+
+	 - Note: A keyboard shortcut's enablement status can be manually adjusted through the `enable(_:)` or `disable(_:)` methods.
+
+	 ```swift
+	 // Check if the "toggleUnicornMode" shortcut is enabled
+	 let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
+	 ```
+	 */
+	public static func isEnabled(for name: Name) -> Bool {
+		guard let shortcut = getShortcut(for: name) else {
+			return false
+		}
+
+		return registeredShortcuts.contains(shortcut)
+	}
 
 	/**
 	Disable the keyboard shortcut for one or more names.

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -197,6 +197,10 @@ public enum KeyboardShortcuts {
 	 ```
 	 */
 	public static func isEnabled(for name: Name) -> Bool {
+		guard isEnabled else {
+			return false
+		}
+		
 		guard let shortcut = getShortcut(for: name) else {
 			return false
 		}

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -182,26 +182,21 @@ public enum KeyboardShortcuts {
 	}
 
 	/**
-	 Check if a keyboard shortcut is enabled for the given name.
+	Returns whether the keyboard shortcut for the given name is enabled.
 
-	 This method checks if the shortcut associated with the given name is currently registered and enabled. Use `enable` or `disable` methods
+	This checks if the shortcut is registered and will trigger handlers. It respects `KeyboardShortcuts.isEnabled`.
 
-	 - Parameter name: The name of the keyboard shortcut to check.
-	 - Returns: `true` if the shortcut is enabled and registered, `false` otherwise.
+	```swift
+	let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
+	```
 
-	 - Note: A keyboard shortcut's enablement status can be manually adjusted through the `enable(_:)` or `disable(_:)` methods.
-
-	 ```swift
-	 	// Check if the "toggleUnicornMode" shortcut is enabled
-		let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
-	 ```
-	 */
+	- Tip: Use ``disable(_:)`` and ``enable(_:)`` to change the status.
+	*/
 	public static func isEnabled(for name: Name) -> Bool {
-		guard isEnabled else {
-			return false
-		}
-
-		guard let shortcut = getShortcut(for: name) else {
+		guard
+			isEnabled,
+			let shortcut = getShortcut(for: name)
+		else {
 			return false
 		}
 

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -192,8 +192,8 @@ public enum KeyboardShortcuts {
 	 - Note: A keyboard shortcut's enablement status can be manually adjusted through the `enable(_:)` or `disable(_:)` methods.
 
 	 ```swift
-	 // Check if the "toggleUnicornMode" shortcut is enabled
-	 let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
+	 	// Check if the "toggleUnicornMode" shortcut is enabled
+		let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
 	 ```
 	 */
 	public static func isEnabled(for name: Name) -> Bool {


### PR DESCRIPTION
This PR adds a function to check the enablement status of a keyboard shortcut that has been set with `enable(_:)` or `disable(_:)`.

I am using this function in my project to implement a SwiftUI Toggle to enable/disable a shortcut without clearing the Shortcut setting in the UserDefaults instance.

## Example
```swift
// Check if the "toggleUnicornMode" shortcut is enabled
let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
```