### PR TITLE
Remove handler of distinct keyboard shortcut

### DIFF
--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -181,6 +181,23 @@ public enum KeyboardShortcuts {
 		legacyKeyUpHandlers = [:]
 	}
 
+	/**
+	Remove the keyboard shortcut handler for the given name.
+	
+	This can be used to reset the handler before re-creating it to avoid having multiple handlers for the same shortcut.
+	
+	- Parameter name: The name of the keyboard shortcut to remove handlers for.
+	*/
+	public static func removeHandler(for name: Name) {
+		legacyKeyDownHandlers[name] = nil
+		legacyKeyUpHandlers[name] = nil
+
+		// make sure not to unregister stream handlers
+		if let shortcut = getShortcut(for: name), !shortcutsForStreamHandlers.contains(shortcut) {
+			unregister(shortcut)
+		}
+	}
+
 	// TODO: Also add `.isEnabled(_ name: Name)`.
 
 	/**

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -192,10 +192,15 @@ public enum KeyboardShortcuts {
 		legacyKeyDownHandlers[name] = nil
 		legacyKeyUpHandlers[name] = nil
 
-		// make sure not to unregister stream handlers
-		if let shortcut = getShortcut(for: name), !shortcutsForStreamHandlers.contains(shortcut) {
-			unregister(shortcut)
+		// Make sure not to unregister stream handlers.
+		guard
+			let shortcut = getShortcut(for: name),
+			!shortcutsForStreamHandlers.contains(shortcut)
+		else {
+			return
 		}
+
+		unregister(shortcut)
 	}
 
 	// TODO: Also add `.isEnabled(_ name: Name)`.

--- a/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -183,10 +183,12 @@ public enum KeyboardShortcuts {
 
 	/**
 	Remove the keyboard shortcut handler for the given name.
-	
+
 	This can be used to reset the handler before re-creating it to avoid having multiple handlers for the same shortcut.
-	
+
 	- Parameter name: The name of the keyboard shortcut to remove handlers for.
+
+	- Note: This method does not affect listeners using `.on()`.
 	*/
 	public static func removeHandler(for name: Name) {
 		legacyKeyDownHandlers[name] = nil


### PR DESCRIPTION
This PR adds a new function to remove the handler of a distinct keyboard shortcut. It extends to public function `removeAllHandlers()` for a more fine-granular control.

My app needs to unload a certain number of models that contain registered shortcuts. Once the module is unloaded, the shortcut should be unregistered. The `removeAllHandlers` does not give me the control to unregister only certain shortcuts.