### PR TITLE
feat: support multicords keybinding recording

### DIFF
--- a/Example/KeyboardShortcutsExample/MainScreen.swift
+++ b/Example/KeyboardShortcutsExample/MainScreen.swift
@@ -8,6 +8,27 @@ extension KeyboardShortcuts.Name {
 	static let testShortcut4 = Self("testShortcut4")
 }
 
+private struct MultiChordRecorder: View {
+    @State private var sequence: ShortcutSequence = .init([])
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Multi-chord Recorder")
+                .bold()
+            Text("Recorded:")
+            Text(sequence.presentableDescription.isEmpty ? "-" : sequence.presentableDescription)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
+            ShortcutRecordView(
+                sequence: $sequence,
+                option: .init(enableSequences: true, maxSequenceLength: 2)
+            )
+        }
+        .frame(maxWidth: 300)
+        .padding()
+    }
+}
+
 private struct DynamicShortcutRecorder: View {
 	@FocusState private var isFocused: Bool
 
@@ -123,14 +144,16 @@ private struct DoubleShortcut: View {
 }
 
 struct MainScreen: View {
-	var body: some View {
-		VStack {
-			DoubleShortcut()
-			Divider()
-			DynamicShortcut()
-		}
-		.frame(width: 400, height: 320)
-	}
+    var body: some View {
+        VStack {
+            DoubleShortcut()
+            Divider()
+            DynamicShortcut()
+            Divider()
+            MultiChordRecorder()
+        }
+        .frame(width: 400, height: 400)
+    }
 }
 
 #Preview {

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -748,6 +748,30 @@ extension KeyboardShortcuts.Shortcut: CustomStringConvertible {
 	}
 }
 
+
+// Represents a sequence of keyboard shortcuts, like `ctrl-k ctrl-s`.
+// This is useful for recording and representing multi-step shortcuts.
+// For example, a sequence can represent pressing “Control-K” followed by “Control-S”.
+public struct ShortcutSequence: Codable, Hashable, Sendable {
+	public var shortcuts: [KeyboardShortcuts.Shortcut]
+
+	public init(_ shortcuts: [KeyboardShortcuts.Shortcut]) {
+		self.shortcuts = shortcuts
+	}
+
+	@MainActor
+	public var presentableDescription: String {
+		shortcuts.map(\.presentableDescription).joined(separator: " ")
+	}
+}
+
+extension [KeyboardShortcuts.Shortcut] {
+	@MainActor
+	var presentableDescription: String {
+		map(\.presentableDescription).joined(separator: " ")
+	}
+}
+
 extension KeyboardShortcuts.Shortcut {
 	@available(macOS 11, *)
 	@MainActor

--- a/Sources/KeyboardShortcuts/ShortcutRecordView.swift
+++ b/Sources/KeyboardShortcuts/ShortcutRecordView.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+import SwiftUI
+  import AppKit
+
+public struct ShortcutRecordView: View {
+  @Binding var shortcut: KeyboardShortcuts.Shortcut?
+
+  public init(shortcut: Binding<KeyboardShortcuts.Shortcut?>) {
+    self._shortcut = shortcut
+  }
+
+  public var body: some View {
+    BindingRecorder(shortcut: $shortcut)
+  }
+}
+
+private struct BindingRecorder: NSViewRepresentable {
+  typealias NSViewType = KeyboardShortcuts.RecorderCocoa
+
+  @Binding var shortcut: KeyboardShortcuts.Shortcut?
+
+  func makeNSView(context: Context) -> NSViewType {
+    let view = KeyboardShortcuts.RecorderCocoa(
+      get: { self.shortcut },
+      set: { self.shortcut = $0 }
+    )
+    return view
+  }
+
+  func updateNSView(_ nsView: NSViewType, context: Context) {
+    nsView.syncDisplayedShortcutFromSource()
+  }
+}
+
+// MARK: - Preview
+#if DEBUG
+struct ShortcutRecordView_Previews: PreviewProvider {
+  private struct Wrapper: View {
+    @State private var shortcut: KeyboardShortcuts.Shortcut? = nil
+    var body: some View {
+      ShortcutRecordView(shortcut: $shortcut)
+        .padding()
+        .frame(width: 240)
+    }
+  }
+
+  static var previews: some View {
+    Wrapper()
+      .frame(width: 260)
+  }
+}
+#endif
+#endif

--- a/Sources/KeyboardShortcuts/ShortcutRecordView.swift
+++ b/Sources/KeyboardShortcuts/ShortcutRecordView.swift
@@ -4,13 +4,18 @@ import SwiftUI
 
 public struct ShortcutRecordView: View {
   @Binding var shortcut: KeyboardShortcuts.Shortcut?
+    let option: KeyboardShortcuts.RecorderOption
 
-  public init(shortcut: Binding<KeyboardShortcuts.Shortcut?>) {
+    public init(
+      shortcut: Binding<KeyboardShortcuts.Shortcut?>,
+      option: KeyboardShortcuts.RecorderOption = KeyboardShortcuts.RecorderOption()
+    ) {
     self._shortcut = shortcut
+      self.option = option
   }
 
   public var body: some View {
-    BindingRecorder(shortcut: $shortcut)
+      BindingRecorder(shortcut: $shortcut, option: option)
   }
 }
 
@@ -18,11 +23,14 @@ private struct BindingRecorder: NSViewRepresentable {
   typealias NSViewType = KeyboardShortcuts.RecorderCocoa
 
   @Binding var shortcut: KeyboardShortcuts.Shortcut?
+    let option: KeyboardShortcuts.RecorderOption
+
 
   func makeNSView(context: Context) -> NSViewType {
     let view = KeyboardShortcuts.RecorderCocoa(
       get: { self.shortcut },
-      set: { self.shortcut = $0 }
+        set: { self.shortcut = $0 },
+        option: option
     )
     return view
   }

--- a/Sources/KeyboardShortcuts/ShortcutRecordView.swift
+++ b/Sources/KeyboardShortcuts/ShortcutRecordView.swift
@@ -1,61 +1,135 @@
 #if os(macOS)
 import SwiftUI
-  import AppKit
+import AppKit
 
+/// A SwiftUI recorder view that supports binding-based recording of a single shortcut
+/// or multi-chord sequences.
+///
+/// - Use `init(shortcut:option:)` to bind to a single `KeyboardShortcuts.Shortcut?`.
+/// - Use `init(sequence:option:)` to bind to a `ShortcutSequence` and enable multi-chord
+///   recording (for example, Ctrl-K Ctrl-S).
+///
+/// Example (multi-chord recording):
+/// ```swift
+/// @State private var sequence: ShortcutSequence = .init([])
+///
+/// var body: some View {
+///     VStack(alignment: .leading) {
+///         Text(sequence.presentableDescription)
+///         ShortcutRecordView(
+///             sequence: $sequence,
+///             option: .init(enableSequences: true, maxSequenceLength: 2)
+///         )
+///     }
+/// }
+/// ```
+///
+/// Note: When `enableSequences` is `true`, the recorder can capture multi-chord
+/// shortcuts like “Ctrl-K Ctrl-S”. Use `maxSequenceLength` to control the maximum
+/// number of chords in the sequence.
 public struct ShortcutRecordView: View {
-  @Binding var shortcut: KeyboardShortcuts.Shortcut?
-    let option: KeyboardShortcuts.RecorderOption
+	@Binding private var shortcuts: [KeyboardShortcuts.Shortcut]
+	private let option: KeyboardShortcuts.RecorderOption
 
-    public init(
-      shortcut: Binding<KeyboardShortcuts.Shortcut?>,
-      option: KeyboardShortcuts.RecorderOption = KeyboardShortcuts.RecorderOption()
-    ) {
-    self._shortcut = shortcut
-      self.option = option
-  }
+	public init(
+		shortcut: Binding<KeyboardShortcuts.Shortcut?>,
+		option: KeyboardShortcuts.RecorderOption = KeyboardShortcuts.RecorderOption()
+	) {
+		let sequenceBinding = Binding<ShortcutSequence>(
+			get: { .init(shortcut.wrappedValue.map { [$0] } ?? []) },
+			set: { sequence in
+				shortcut.wrappedValue = sequence.shortcuts.first
+			}
+		)
 
-  public var body: some View {
-      BindingRecorder(shortcut: $shortcut, option: option)
-  }
+		var option = option
+		if option.enableSequences {
+			assertionFailure("The `shortcut` binding does not support sequences. Please use the `sequence` binding instead.")
+			option = .init(
+				allowOnlyShiftModifier: option.allowOnlyShiftModifier,
+				checkMenuCollision: option.checkMenuCollision,
+				enableSequences: false,
+				maxSequenceLength: 1
+			)
+		}
+
+		self.init(sequence: sequenceBinding, option: option)
+	}
+
+	public init(
+		sequence: Binding<ShortcutSequence>,
+		option: KeyboardShortcuts.RecorderOption = KeyboardShortcuts.RecorderOption()
+	) {
+		self._shortcuts = Binding(
+			get: { sequence.wrappedValue.shortcuts },
+			set: { newShortcuts in
+				sequence.wrappedValue.shortcuts = newShortcuts
+			}
+		)
+		self.option = option
+	}
+
+	public var body: some View {
+		BindingRecorder(shortcuts: $shortcuts, option: option)
+	}
 }
 
 private struct BindingRecorder: NSViewRepresentable {
-  typealias NSViewType = KeyboardShortcuts.RecorderCocoa
+	typealias NSViewType = KeyboardShortcuts.RecorderCocoa
 
-  @Binding var shortcut: KeyboardShortcuts.Shortcut?
-    let option: KeyboardShortcuts.RecorderOption
+	@Binding var shortcuts: [KeyboardShortcuts.Shortcut]
+	let option: KeyboardShortcuts.RecorderOption
 
+	func makeNSView(context: Context) -> NSViewType {
+		let view = KeyboardShortcuts.RecorderCocoa(
+			get: { self.shortcuts },
+			set: { self.shortcuts = $0 },
+			option: option
+		)
+		return view
+	}
 
-  func makeNSView(context: Context) -> NSViewType {
-    let view = KeyboardShortcuts.RecorderCocoa(
-      get: { self.shortcut },
-        set: { self.shortcut = $0 },
-        option: option
-    )
-    return view
-  }
-
-  func updateNSView(_ nsView: NSViewType, context: Context) {
-    nsView.syncDisplayedShortcutFromSource()
-  }
+		func updateNSView(_ nsView: NSViewType, context: Context) {
+		}
 }
 
 // MARK: - Preview
 #if DEBUG
 struct ShortcutRecordView_Previews: PreviewProvider {
-  private struct Wrapper: View {
-    @State private var shortcut: KeyboardShortcuts.Shortcut? = nil
-    var body: some View {
-      ShortcutRecordView(shortcut: $shortcut)
-        .padding()
-        .frame(width: 240)
-    }
-  }
+	private struct SingleShortcutWrapper: View {
+		@State private var shortcut: KeyboardShortcuts.Shortcut? = .init(.a, modifiers: .command)
 
-  static var previews: some View {
-    Wrapper()
-      .frame(width: 260)
-  }
+		var body: some View {
+			VStack {
+				Text("Recorded: \(shortcut?.description ?? "none")")
+				ShortcutRecordView(shortcut: $shortcut)
+			}
+			.padding()
+		}
+	}
+
+	private struct SequenceWrapper: View {
+		@State private var sequence: ShortcutSequence = .init([
+			.init(.k, modifiers: .control),
+			.init(.s, modifiers: .control)
+		])
+
+		var body: some View {
+			VStack {
+				Text("Recorded: \(sequence.presentableDescription)")
+				ShortcutRecordView(sequence: $sequence, option: .init(enableSequences: true, maxSequenceLength: 2))
+			}
+			.padding()
+		}
+	}
+
+	static var previews: some View {
+		VStack(spacing: 20) {
+			SingleShortcutWrapper()
+			SequenceWrapper()
+		}
+		.frame(width: 260)
+	}
 }
 #endif
 #endif

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,35 @@ final class SettingsViewController: NSViewController {
 }
 ```
 
+#### Cocoa binding mode (no built-in persistence)
+
+If you prefer to manage storage yourself (for example, to bind into your own state or model), use the binding initializer:
+
+```swift
+import AppKit
+import KeyboardShortcuts
+
+final class SettingsViewController: NSViewController {
+    var customShortcut: KeyboardShortcuts.Shortcut?
+
+    override func loadView() {
+        view = NSView()
+
+        let recorder = KeyboardShortcuts.RecorderCocoa(
+            get: { [weak self] in self?.customShortcut },
+            set: { [weak self] in self?.customShortcut = $0 }
+        )
+
+        view.addSubview(recorder)
+    }
+}
+```
+
+Note about callbacks:
+
+- `onChange` is only available and triggered in the persist-based APIs (for example, `RecorderCocoa(for:onChange:)` and the SwiftUI `KeyboardShortcuts.Recorder`).
+- In binding mode (`RecorderCocoa(get:set:)`), side-effects should be handled in your `set` closure. There is no `onChange` parameter in this initializer.
+
 ## Localization
 
 This package supports [localizations](/Sources/KeyboardShortcuts/Localization). PR welcome for more!

--- a/readme.md
+++ b/readme.md
@@ -114,34 +114,34 @@ final class SettingsViewController: NSViewController {
 }
 ```
 
-#### Cocoa binding mode (no built-in persistence)
+#### SwiftUI binding mode (no built-in persistence, supports multi-chord sequences)
 
-If you prefer to manage storage yourself (for example, to bind into your own state or model), use the binding initializer:
+If you prefer to manage storage yourself (for example, to bind into your own state or model) and/or want to support multi-chord shortcuts like “Ctrl-K Ctrl-S”, use `ShortcutRecordView` with a binding. You can enable multi-chord recording by turning on sequences and setting a max length.
 
 ```swift
-import AppKit
+import SwiftUI
 import KeyboardShortcuts
 
-final class SettingsViewController: NSViewController {
-    var customShortcut: KeyboardShortcuts.Shortcut?
+struct SettingsView: View {
+    // Store in your own model/state. This supports multi-chord sequences like Ctrl-K Ctrl-S.
+    @State private var sequence: ShortcutSequence = .init([])
 
-    override func loadView() {
-        view = NSView()
-
-        let recorder = KeyboardShortcuts.RecorderCocoa(
-            get: { [weak self] in self?.customShortcut },
-            set: { [weak self] in self?.customShortcut = $0 }
-        )
-
-        view.addSubview(recorder)
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Shortcut: \(sequence.presentableDescription.isEmpty ? "–" : sequence.presentableDescription)")
+            // Enable multi-chord recording by turning on `enableSequences`.
+            ShortcutRecordView(
+                sequence: $sequence,
+                option: .init(enableSequences: true, maxSequenceLength: 2)
+            )
+        }
+        .padding()
     }
 }
 ```
 
 Note about callbacks:
-
-- `onChange` is only available and triggered in the persist-based APIs (for example, `RecorderCocoa(for:onChange:)` and the SwiftUI `KeyboardShortcuts.Recorder`).
-- In binding mode (`RecorderCocoa(get:set:)`), side-effects should be handled in your `set` closure. There is no `onChange` parameter in this initializer.
+- In binding mode (`ShortcutRecordView(sequence:)`), handle side-effects in your bound state update. There is no `onChange` parameter in these initializers.
 
 ## Localization
 


### PR DESCRIPTION
Add `ShortcutRecordView` to support multicords keybinding recording, for example, `Ctrl-K Ctrl-S`.

Note that it does not support `KeyboardShortcuts.onKeyDown` and `KeyboardShortcuts.onKeyUp` yet