### PR TITLE
Make toSwiftUI public

### DIFF
--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -754,7 +754,7 @@ extension KeyboardShortcuts.Shortcut: CustomStringConvertible {
 extension KeyboardShortcuts.Shortcut {
 	@available(macOS 11, *)
 	@MainActor
-	var toSwiftUI: KeyboardShortcut? {
+	public var toSwiftUI: KeyboardShortcut? {
 		if
 			let key,
 			let specialKey = keyToSpecialKeyMapping[key]


### PR DESCRIPTION
Looking to do something like this in a menu where there is an optional preference and falls back to a default.

```swift
Button("New Item") {}
    .keyboardShortcut(newItemKeyboardShortcutPref?.toSwiftUI ?? .init("n"))
```