### PR TITLE
Fix option+letter shortcuts being intercepted by IME layer

### DIFF
--- a/Sources/KeyboardShortcuts/HotKey.swift
+++ b/Sources/KeyboardShortcuts/HotKey.swift
@@ -117,6 +117,8 @@ final class HotKeyCenter {
 		return nil
 	}
 
+	private var globalEventMonitor: AnyObject?
+
 	var mode: Mode = .normal {
 		didSet {
 			guard mode != oldValue else {
@@ -219,6 +221,7 @@ final class HotKeyCenter {
 		}
 
 		hotKeys.removeValue(forKey: hotKey.id)
+		updateEventHandler()
 	}
 
 	private func pause(_ hotKey: HotKey) {
@@ -324,6 +327,38 @@ final class HotKeyCenter {
 
 		setHotKeyEventHandlingEnabled(shouldHandleHotKeys)
 		setRawKeyEventHandlingEnabled(shouldHandleRawKeys)
+		setGlobalOptionKeyMonitorEnabled(mode == .normal && hasOptionOnlyShortcuts)
+	}
+
+	/**
+	Returns true if any registered shortcut uses Option as the only modifier (no Command or Control).
+	Such shortcuts are prone to being intercepted by the IME layer before Carbon receives them.
+	*/
+	private var hasOptionOnlyShortcuts: Bool {
+		hotKeys.values.compactMap(\.value).contains { hotKey in
+			let modifiers = NSEvent.ModifierFlags(carbon: hotKey.carbonModifiers)
+			return modifiers.contains(.option)
+				&& !modifiers.contains(.command)
+				&& !modifiers.contains(.control)
+		}
+	}
+
+	private func setGlobalOptionKeyMonitorEnabled(_ isEnabled: Bool) {
+		if isEnabled, globalEventMonitor == nil {
+			globalEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown, .keyUp]) { [weak self] event in
+				guard
+					let self,
+					let eventRef = OpaquePointer(event.eventRef)
+				else {
+					return
+				}
+
+				_ = handleRawKeyEvent(eventRef)
+			}
+		} else if !isEnabled, let monitor = globalEventMonitor {
+			NSEvent.removeMonitor(monitor)
+			globalEventMonitor = nil
+		}
 	}
 
 	private func setHotKeyEventHandlingEnabled(_ isEnabled: Bool) {

--- a/Sources/KeyboardShortcuts/HotKey.swift
+++ b/Sources/KeyboardShortcuts/HotKey.swift
@@ -337,9 +337,7 @@ final class HotKeyCenter {
 	private var hasOptionOnlyShortcuts: Bool {
 		hotKeys.values.compactMap(\.value).contains { hotKey in
 			let modifiers = NSEvent.ModifierFlags(carbon: hotKey.carbonModifiers)
-			return modifiers.contains(.option)
-				&& !modifiers.contains(.command)
-				&& !modifiers.contains(.control)
+			return modifiers == [.option]
 		}
 	}
 


### PR DESCRIPTION
Fixes #235

## Problem

Shortcuts using `option + letter` (e.g. `option + q`) stop working intermittently. `option + number` works reliably. Re-opening the app's settings window temporarily restores them.

**Root cause:** Carbon's `RegisterEventHotKey` doesn't receive events for `option + letter` combinations because macOS processes them through the Text Services Manager / IME layer first (e.g. `option + q` → `œ`). The Carbon event never fires. This doesn't affect `option + number` because digits don't participate in IME character composition.

The existing `RunLoopLocalEventMonitor` with `.eventTracking` already solves this correctly for the menu-open case, since it intercepts raw key events before IME. This PR extends the same approach to the normal (non-menu) mode.

## Fix

When at least one registered shortcut uses `option` without `command` or `control` (the only combinations affected by IME), a `NSEvent.addGlobalMonitorForEvents` listener is activated alongside the normal Carbon hotkey handler.

The global monitor handles key matching via the existing `handleRawKeyEvent` path — no new matching logic needed. It is automatically enabled/disabled as shortcuts are registered/unregistered, and torn down entirely when no option-only shortcuts remain.

## Scope

Only `option`-only shortcuts (no `cmd`/`ctrl`) are affected. Adding `command` or `control` prevents IME interception — those shortcuts continue using Carbon exclusively.