### PR TITLE
Expose isTakenBySystem and isDisallowed

### DIFF
--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -107,7 +107,7 @@ extension KeyboardShortcuts.Shortcut {
 	/**
 	Check whether the keyboard shortcut is disallowed.
 	*/
-	var isDisallowed: Bool {
+	public var isDisallowed: Bool {
 		let osVersion = ProcessInfo.processInfo.operatingSystemVersion
 
 		guard
@@ -130,7 +130,7 @@ extension KeyboardShortcuts.Shortcut {
 	/**
 	Check whether the keyboard shortcut is already taken by the system.
 	*/
-	var isTakenBySystem: Bool {
+	public var isTakenBySystem: Bool {
 		guard self != Self(.f12, modifiers: []) else {
 			return false
 		}

--- a/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/Sources/KeyboardShortcuts/Shortcut.swift
@@ -137,6 +137,13 @@ extension KeyboardShortcuts.Shortcut {
 
 		return Self.system.contains(self)
 	}
+	
+	/**
+	Check whether the keyboard shortcut is already taken by main menu.
+	*/
+	public var isTakenByMainMenu: Bool {
+		return self.takenByMainMenu != nil
+	}
 }
 
 extension KeyboardShortcuts.Shortcut {


### PR DESCRIPTION
Expose Shortcut.isTakenBySystem and Shortcut.isDisallowed to make it easier to implement custom recorder UIs.